### PR TITLE
fix(ai): background cliproxyapi start to prevent make ai hang

### DIFF
--- a/include.ai.mk
+++ b/include.ai.mk
@@ -434,7 +434,7 @@ ai-auth:
 CLIPROXYAPI_PORT ?= 8080
 .PHONY: cliproxyapi
 cliproxyapi:
-	command -v cliproxyapi >/dev/null || { echo "cliproxyapi not installed — run: brew install cliproxyapi"; exit 1; }
+	command -v cliproxyapi >/dev/null || brew install cliproxyapi
 	$(call start_server_self,$(CLIPROXYAPI_PORT),cliproxyapi start)
 	$(call check_port,$(CLIPROXYAPI_PORT))
 

--- a/include.ai.mk
+++ b/include.ai.mk
@@ -434,7 +434,7 @@ ai-auth:
 CLIPROXYAPI_PORT ?= 8080
 .PHONY: cliproxyapi
 cliproxyapi:
-	command -v cliproxyapi >/dev/null || brew install cliproxyapi
+	command -v cliproxyapi >/dev/null || { echo "cliproxyapi not installed — run: brew install cliproxyapi"; exit 1; }
 	$(call start_server_self,$(CLIPROXYAPI_PORT),cliproxyapi start)
 	$(call check_port,$(CLIPROXYAPI_PORT))
 

--- a/include.ai.mk
+++ b/include.ai.mk
@@ -373,7 +373,7 @@ ai-warn-bridges:
 	@if ! nc -z localhost $(CLIPROXYAPI_PORT) 2>/dev/null; then \
 		echo "  → gemini bridge (:$(CLIPROXYAPI_PORT)) not running — starting..."; \
 		if command -v cliproxyapi >/dev/null 2>&1; then \
-			$(call start_server_self,$(CLIPROXYAPI_PORT),cliproxyapi start); \
+			nohup cliproxyapi start </dev/null >$(TNE_LOG_DIR)/sidecar-$(CLIPROXYAPI_PORT).log 2>&1 & \
 			sleep 2; \
 			if nc -z localhost $(CLIPROXYAPI_PORT) 2>/dev/null; then \
 				echo "  ✓  gemini bridge started"; \


### PR DESCRIPTION
## Summary
- `start_server_self` runs `cliproxyapi start` in the foreground inside the recipe shell
- If `cliproxyapi` doesn't self-daemonize it blocks `make ai` indefinitely
- Fix: use `nohup cliproxyapi start ... &` directly, matching the kimi bridge pattern

## Test plan
- [ ] `make ai` completes without hanging when cliproxyapi is not running

🤖 Generated with [Claude Code](https://claude.com/claude-code)