### PR TITLE
fix(ai): use claude-code-proxy serve for kimi bridge

### DIFF
--- a/include.ai.mk
+++ b/include.ai.mk
@@ -357,7 +357,7 @@ ai-warn-bridges:
 	@if ! nc -z localhost $(KIMI_CLAUDE_PROXY_PORT) 2>/dev/null; then \
 		echo "  → kimi bridge (:$(KIMI_CLAUDE_PROXY_PORT)) not running — starting..."; \
 		if command -v claude-code-proxy >/dev/null 2>&1; then \
-			nohup claude-code-proxy kimi start </dev/null >$(TNE_LOG_DIR)/kimi-proxy.log 2>&1 & \
+			PORT=$(KIMI_CLAUDE_PROXY_PORT) nohup claude-code-proxy serve </dev/null >$(TNE_LOG_DIR)/kimi-proxy.log 2>&1 & \
 			sleep 2; \
 			if nc -z localhost $(KIMI_CLAUDE_PROXY_PORT) 2>/dev/null; then \
 				echo "  ✓  kimi bridge started"; \


### PR DESCRIPTION
## Summary
- Fix `ai-warn-bridges`: `claude-code-proxy kimi start` → `PORT=$(KIMI_CLAUDE_PROXY_PORT) claude-code-proxy serve`
- `kimi start` is not a valid subcommand; `serve` is the only run command and reads port from `PORT` env

## Test plan
- [ ] `make ai` — kimi bridge auto-starts on :3457 (after `make ai-auth PROVIDER=kimi`)
- [ ] `make ai-run MODEL=kimi-k2.6` succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)