### PR TITLE
fix(ai-help): dynamic cloud model list from LITELLM_CFG

### DIFF
--- a/include.ai.mk
+++ b/include.ai.mk
@@ -367,13 +367,9 @@ ai-help:
 	@echo ""
 	@echo "  ── Cloud / Subscription ─────────────────────────────────────────────────"
 	@echo "    make ai-run                               # claude Max plan (default)"
-	@printf '    make ai-run MODEL=%-32s # %s\n' \
-		kimi-k2.6   "Kimi K2 Coding Plan \$$19/mo  [PLAN]" \
-		kimi-k2.5   "Kimi K2.5 Coding Plan         [PLAN]" \
-		glm-5       "GLM-5 via Z.AI                [PAYG]" \
-		minimax-m2  "MiniMax M2                    [PAYG]" \
-		qwen-code   "Qwen DashScope Coding Plan    [PLAN]" \
-		gemini-2.5-flash "Gemini Flash             [PAYG]" 2>/dev/null || true
+	@yq '.model_list[].model_name' "$(LITELLM_CFG)" 2>/dev/null \
+		| grep -v '^lls/' | grep -v '^lms/' | sort \
+		| while IFS= read -r name; do printf '    make ai-run MODEL=%-36s\n' "$$name"; done
 	@echo ""
 	@echo "  ── Local GPU (llama-server) ─────────────────────────────────────────────"
 	@if nc -z localhost $(LLS_PORT) 2>/dev/null; then \


### PR DESCRIPTION
## Summary

- Replaces hardcoded model names (`glm-5`, `minimax-m2`, `qwen-code`) in `ai-help` with a `yq`-based dynamic list that reads all non-`lls/`/`lms/` model names from `LITELLM_CFG` at runtime
- Stays in sync with `~/.config/litellm/config.yaml` automatically — no manual updates needed when models are added/removed

Also fixed separately (not in this PR — direct config edit):
- `~/.config/litellm/config.yaml`: GLM entries changed from `openai/glm-*` with Anthropic endpoint URL to `anthropic/glm-*` with correct `api_base: https://api.z.ai/api/anthropic`

## Test plan

- [ ] `make ai-help` shows all non-lls cloud models from config
- [ ] Adding a new model to `config.yaml` appears in `make ai-help` without any code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)