### PR TITLE
fix(ai): skip claude-* in ai-test-models — OAuth not testable via curl

### DIFF
--- a/include.ai.mk
+++ b/include.ai.mk
@@ -683,10 +683,8 @@ ai-test-models:
 			| grep -v '^lms/' | grep -v '^lls/'); do \
 		case "$$model" in \
 		claude-*) \
-			reply=$$(ANTHROPIC_BASE_URL=http://localhost:$(LITELLM_PORT) \
-				ANTHROPIC_API_KEY="$${LITELLM_MASTER_KEY}" \
-				claude -p "reply with the single word: pong" --model "$$model" \
-				--max-turns 1 2>/dev/null | tr -d '\n' | cut -c1-60); \
+			echo "  – $$model: skipped (Max plan OAuth — tested implicitly via Claude Code session)"; \
+			continue; \
 			;; \
 		*) \
 			result=$$(curl -sf --max-time 30 -X POST \


### PR DESCRIPTION
## Summary

- `ai-test-models` now skips `claude-*` models with a note instead of false-passing or hanging
- Root cause: `forward_client_headers_to_llm_api: true` means LiteLLM forwards the client bearer to Anthropic — `LITELLM_MASTER_KEY` is not a valid Anthropic API key, so any curl/`claude -p` test with it will get a 401
- claude-* models are tested implicitly via every live Claude Code session (this conversation routes through LiteLLM)

## Test plan

- [x] `make ai-test-models` completes without hanging on claude-* models
- [x] claude-* shows `– skipped (Max plan OAuth — tested implicitly via Claude Code session)`
- [x] PAYG models (glm, deepseek) still tested normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)