### PR TITLE
feat(ai): PLAN-only config, Z_AI_PLAN_KEY, ai-keys target

### DIFF
--- a/include.ai.mk
+++ b/include.ai.mk
@@ -529,6 +529,7 @@ ai-open:
 		open -a "Google Chrome" "https://console.anthropic.com/settings/usage" || true; \
 		open -a "Google Chrome" "https://platform.moonshot.cn/console/account" || true; \
 		open -a "Google Chrome" "https://aistudio.google.com/app/apikey" || true; \
+		open -a "Google Chrome" "https://z.ai/manage-apikey/billing" || true; \
 		touch "$(AI_OPEN_STAMP)"; \
 	fi
 

--- a/include.ai.mk
+++ b/include.ai.mk
@@ -686,12 +686,23 @@ ai-test-models:
 			echo "  – $$model: skipped (Max plan OAuth — tested implicitly via Claude Code session)"; \
 			continue; \
 			;; \
+		kimi-*) \
+			result=$$(curl -sf --max-time 30 -X POST \
+				http://localhost:$(LITELLM_PORT)/v1/chat/completions \
+				-H "Content-Type: application/json" \
+				-H "Authorization: Bearer $${LITELLM_MASTER_KEY}" \
+				-d "{\"model\":\"$$model\",\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"reply with the single word: pong\"}],\"max_tokens\":200}" \
+				2>&1); \
+			reply=$$(echo "$$result" | grep '"content"' | grep -v '"content":""' \
+				| python3 -c 'import sys,json,re; chunks=[l for l in sys.stdin if l.startswith("data:")]; last=[c for c in chunks if "content" in c and json.loads(c[5:]).get("choices",[{}])[0].get("delta",{}).get("content","")]; print("".join(json.loads(c[5:])["choices"][0]["delta"]["content"] for c in last).strip()[:60])' \
+				2>/dev/null); \
+			;; \
 		*) \
 			result=$$(curl -sf --max-time 30 -X POST \
 				http://localhost:$(LITELLM_PORT)/v1/chat/completions \
 				-H "Content-Type: application/json" \
 				-H "Authorization: Bearer $${LITELLM_MASTER_KEY}" \
-				-d "{\"model\":\"$$model\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with the single word: pong\"}],\"max_tokens\":20}" \
+				-d "{\"model\":\"$$model\",\"messages\":[{\"role\":\"user\",\"content\":\"reply with the single word: pong\"}],\"max_tokens\":200}" \
 				2>&1); \
 			reply=$$(echo "$$result" | python3 -c \
 				'import sys,json; r=json.load(sys.stdin); m=r["choices"][0]["message"]; print((m.get("content") or m.get("reasoning_content","")).strip()[:60])' \
@@ -802,6 +813,8 @@ ai-install:
 	for pkg in codex gemini-cli qwen-code kimi-cli; do \
 		command -v "$$pkg" >/dev/null 2>&1 || brew install "$$pkg" 2>/dev/null || echo "  ($$pkg not in brew — skip)"; \
 	done
+	echo "==> brew: CLIProxyAPI (wraps gemini-cli/codex as OpenAI-compatible API on :8317)"
+	command -v cliproxyapi >/dev/null 2>&1 || brew install cliproxyapi 2>/dev/null || echo "  (cliproxyapi not in brew — skip)"
 	echo "==> uv: litellm proxy + mlflow tracking"
 	uv tool install 'litellm[proxy]' 2>/dev/null || uvx litellm --version >/dev/null
 	uv tool install mlflow 2>/dev/null || uvx mlflow --version >/dev/null

--- a/include.ai.mk
+++ b/include.ai.mk
@@ -563,12 +563,12 @@ ai-models:
 			*-free)    tag="FREE  -- provider free tier via OpenRouter" ;; \
 			claude*)   tag="PLAN  -- Anthropic Max (~\$$20-100/mo flat)" ;; \
 			kimi*)     tag="PLAN  -- Kimi Coding Plan (\$$19/mo flat)" ;; \
-			glm*)      tag="PLAN  -- ZAI Coding Plan (~\$$10/mo flat)" ;; \
-			qwen3*)    tag="PLAN  -- Qwen Coding Plan (\$$50/mo flat)" ;; \
-			minimax*)  tag="PLAN  -- MiniMax plan" ;; \
+			glm*)      tag="PLAN  -- ZAI GLM Coding Plan \$$18/mo → Z_AI_PLAN_KEY" ;; \
+			qwen3*)    tag="PLAN  -- Qwen Coding \$$50/mo → QWEN_CODING_API_KEY" ;; \
+			minimax*)  tag="PLAN  -- MiniMax Token Plan \$$10-20/mo → MINIMAX_PLAN_KEY" ;; \
 			routellm*) tag="PLAN+PLAN -- auto-routes kimi->claude by difficulty" ;; \
-			gemini*)   tag="PAYG  -- pay per token (flash: free tier available)" ;; \
-			deepseek*) tag="PAYG  -- pay per token" ;; \
+			gemini*)   tag="PLAN  -- Google CLI sub → make ai-auth PROVIDER=gemini" ;; \
+			deepseek*) tag="PAYG  -- no flat-rate plan; use sparingly" ;; \
 			*)         tag="PAYG" ;; \
 			esac; \
 			printf '  make ai MODEL=%-32s # %s\n' "$$name" "$$tag"; \
@@ -587,6 +587,31 @@ ai-models:
 	echo "  make ai-cli MODEL=codex              # PLAN  — codex login"
 	echo "  make ai-cli MODEL=gemini-proxy       # PLAN  — gemini auth login"
 	echo "  make ai-auto                         # PLAN+PLAN — kimi (easy) → claude (hard)"
+
+## ai-keys: show which env vars are required for each PLAN provider and where to get them
+## Sources:
+##   Z.AI:    https://z.ai/subscribe → account → API Keys (regular key, no special prefix)
+##   MiniMax: https://platform.minimax.io/subscribe/token-plan — Token Plan $10-20/mo
+##   Qwen:    https://help.aliyun.com/zh/model-studio/qwen-coder — coding plan key
+##   Gemini:  make ai-auth PROVIDER=gemini — Google OAuth via cliproxyapi
+##   Kimi:    claude-code-proxy handles auth — no extra key needed
+.PHONY: ai-keys
+ai-keys:
+	@echo "══ PLAN provider keys (set in .envrc or 1Password) ══════"
+	@printf "  %-28s %s\n" "Z_AI_PLAN_KEY" \
+		"$$([ -n "$$Z_AI_PLAN_KEY" ] && echo "✓ set" || echo "✗ missing — z.ai → account → API Keys")"
+	@printf "  %-28s %s\n" "MINIMAX_PLAN_KEY" \
+		"$$([ -n "$$MINIMAX_PLAN_KEY" ] && echo "✓ set" || echo "✗ missing — platform.minimax.io/subscribe/token-plan")"
+	@printf "  %-28s %s\n" "QWEN_CODING_API_KEY" \
+		"$$([ -n "$$QWEN_CODING_API_KEY" ] && echo "✓ set" || echo "✗ missing — Alibaba Cloud console → Model Studio → API Keys")"
+	@printf "  %-28s %s\n" "LITELLM_MASTER_KEY" \
+		"$$([ -n "$$LITELLM_MASTER_KEY" ] && echo "✓ set" || echo "✗ missing — generate random, set in 1Password")"
+	@echo ""
+	@echo "══ PLAN providers requiring OAuth (no API key) ══════════"
+	@printf "  %-28s %s\n" "Gemini (CLIProxyAPI)" \
+		"$$(cliproxyapi status 2>/dev/null | grep -q authenticated && echo "✓ authenticated" || echo "✗ run: make ai-auth PROVIDER=gemini")"
+	@printf "  %-28s %s\n" "Kimi (claude-code-proxy)" \
+		"$$($(call port_ready,3457) && echo "✓ running :3457" || echo "✗ run: make ai")"
 
 ## ai-logs: push Claude Code session logs to MLflow
 .PHONY: ai-logs


### PR DESCRIPTION
## Summary

- **PLAN-only config**: remove all PAYG models (deepseek-*, old glm/minimax PAYG keys) from litellm config.yaml
- **Z.AI GLM**: switch from `Z_AI_API_KEY` (PAYG `sk-*`) to `Z_AI_PLAN_KEY` (subscription `sk-sp-*`). Source: [z.ai/subscribe](https://z.ai/subscribe) — "All GLM Coding Plan subscriptions come with a unique API key prefixed with sk-sp-"
- **MiniMax**: switch from `MINIMAX_API_KEY` to `MINIMAX_PLAN_KEY`. Source: [Token Plan docs](https://platform.minimax.io/docs/guides/pricing-token-plan) — same endpoint, billing determined by key
- **DeepSeek removed**: no flat-rate plan exists. Source: [deepseeksr1.com/pricing](https://deepseeksr1.com/pricing)
- **`make ai-keys`**: new target showing which env vars are set/missing with source URLs for getting each key
- **`make ai MODEL=...` listing**: updated tags to show correct env var name per model

## Required env vars (liveInputs)

| Var | Provider | Where to get |
|---|---|---|
| `Z_AI_PLAN_KEY` | Z.AI GLM | [z.ai/subscribe](https://z.ai/subscribe) — get `sk-sp-*` key |
| `MINIMAX_PLAN_KEY` | MiniMax M2.7 | [platform.minimax.io/subscribe/token-plan](https://platform.minimax.io/subscribe/token-plan) |
| `QWEN_CODING_API_KEY` | Qwen | Alibaba Cloud console → Model Studio → API Keys |
| `LITELLM_MASTER_KEY` | All models | Random string, stored in 1Password |

## Test plan

- [ ] `make ai-keys` shows ✓/✗ for each key
- [ ] `make ai-test-models` with correct keys: glm-5.1, minimax-m2.7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)