### PR TITLE
feat(make-ai): add tne-engine-worker to ai-install + temporal

### DIFF
--- a/api-keys.yaml
+++ b/api-keys.yaml
@@ -1,0 +1,343 @@
+# api-keys.yaml — single source of truth for all API key metadata
+# No secrets stored here — only metadata about where secrets live and how to use them.
+#
+# Fields:
+#   op_item:          1Password item title (required)
+#   op_field:         field name within item (default: "api key")
+#   op_vault:         1Password vault (default: DevOps)
+#   disabled_by:      skip loading if this env var is set + non-empty
+#   disabled:         hard-disable entry entirely (default: false)
+#   equivalent_of:    export this var equal to another env var instead of loading from op
+#
+#   models_url:       provider /v1/models endpoint (AI providers only)
+#   models_auth:      bearer (default) | query — how to pass the key
+#   models_auth_param: query param name when models_auth=query (default: key)
+#   models_pattern:   regex to filter model IDs from the response
+#   litellm_base:     API base URL for litellm model_list
+#   litellm_key_env:  env var name for api_key in litellm config (default: same as key)
+#   litellm_model_prefix: litellm model prefix e.g. "openai/" "gemini/" (default: "openai/")
+#   ccr_provider:     provider name in ~/.claude-code-router/config.json
+
+# ── Anthropic ─────────────────────────────────────────────────────────────────
+ANTHROPIC_API_KEY_REAL:
+  op_item: "Anthropic API Key Dev"
+  op_vault: DevOps
+  disabled_by: ANTHROPIC_MAX
+  models_url: https://api.anthropic.com/v1/models
+  models_pattern: "claude-"
+
+# ANTHROPIC_API_KEY is NOT loaded from 1Password directly.
+# When LiteLLM is running, make ai-run sets it to LITELLM_MASTER_KEY so Claude Code
+# passes LiteLLM's auth gate. Setting it here would bill against API quotas.
+ANTHROPIC_API_KEY:
+  disabled: true
+
+# ── AWS ───────────────────────────────────────────────────────────────────────
+AWS_ACCESS_KEY_ID:
+  op_item: "AWS Access Key"
+  op_field: "access key id"
+  op_vault: DevOps
+
+AWS_SECRET_ACCESS_KEY:
+  op_item: "AWS Access Key"
+  op_field: "secret access key"
+  op_vault: DevOps
+
+# ── AI Coding Plan providers ──────────────────────────────────────────────────
+MINIMAX_API_KEY:
+  op_item: "Minimax API Key Dev"
+  op_field: "MiniMax API Key Dev"
+  op_vault: DevOps
+  models_url: https://api.minimax.io/v1/models
+  models_pattern: "^MiniMax-M"
+  litellm_base: https://api.minimax.io/v1
+  litellm_model_prefix: "openai/"
+  ccr_provider: minimax
+
+Z_AI_API_KEY:
+  op_item: "Z.ai API Key Dev"
+  op_vault: DevOps
+  models_url: https://api.z.ai/api/v1/models
+  models_pattern: "^glm-5"
+  litellm_base: https://api.z.ai/api/anthropic/v1/messages
+  litellm_key_env: ZHIPUAI_API_KEY
+  litellm_model_prefix: "openai/"
+  ccr_provider: z.ai
+
+MOONSHOT_API_KEY:
+  op_item: "Moonshot API Key Dev"
+  op_vault: DevOps
+  disabled: true  # PAYG — use claude-code-proxy for Kimi Coding Plan
+  models_url: https://api.moonshot.cn/v1/models
+  models_pattern: "^kimi-k2"
+  litellm_base: https://api.moonshot.cn/v1
+  litellm_model_prefix: "openai/"
+  ccr_provider: kimi
+
+QWEN_CODING_API_KEY:
+  op_item: "Alibaba Dashscope API Key Dev"
+  op_vault: DevOps
+  models_url: https://coding-intl.dashscope.aliyuncs.com/compatible-mode/v1/models
+  models_pattern: "^qwen3-coder"
+  litellm_base: https://coding-intl.dashscope.aliyuncs.com/apps/anthropic
+  litellm_model_prefix: "openai/"
+  ccr_provider: dashscope
+
+ALIBABA_API_KEY:
+  op_item: "Alibaba Dashscope API Key Dev"
+  op_vault: DevOps
+
+DEEPSEEK_API_KEY:
+  op_item: "deepseek API Key Dev"
+  op_vault: DevOps
+  models_url: https://api.deepseek.com/v1/models
+  models_pattern: "^deepseek-"
+  litellm_base: https://api.deepseek.com/v1
+  litellm_model_prefix: "openai/"
+  ccr_provider: deepseek
+
+OPENROUTER_API_KEY:
+  op_item: "OpenRouter API Key Dev"
+  op_field: "key"
+  op_vault: DevOps
+  models_url: https://openrouter.ai/api/v1/models
+  models_pattern: "."
+  ccr_provider: openrouter
+
+# ── Google ────────────────────────────────────────────────────────────────────
+GEMINI_API_KEY:
+  op_item: "Google Gemini API Key Dev"
+  op_vault: DevOps
+  disabled_by: GEMINI_OAUTH  # gemini auth login overrides API key in Gemini CLI
+  models_url: https://generativelanguage.googleapis.com/v1beta/models
+  models_auth: query
+  models_auth_param: key
+  models_pattern: "^gemini-"
+  litellm_model_prefix: "gemini/"
+  ccr_provider: gemini
+
+GOOGLE_API_KEY:
+  op_item: "Google Gemini API Key Dev"
+  op_vault: DevOps
+  disabled_by: GEMINI_OAUTH
+  equivalent_of: GEMINI_API_KEY
+
+GOOGLE_MAPS_API_KEY:
+  op_item: "Google Maps API Key Dev"
+  op_vault: DevOps
+
+# ── OpenAI / Codex ────────────────────────────────────────────────────────────
+OPENAI_API_KEY:
+  op_item: "OpenAI API Key Dev"
+  op_vault: DevOps
+  disabled_by: CODEX_CHATGPT  # codex login ChatGPT OAuth overrides API key
+
+OPENCODE_API_KEY:
+  op_item: "OpenCode API Key Dev"
+  op_vault: DevOps
+
+# ── LiteLLM ───────────────────────────────────────────────────────────────────
+LITELLM_MASTER_KEY:
+  op_item: "LiteLLM Auth Token Dev"
+  op_field: "auth token"
+  op_vault: DevOps
+
+# ── Search & data providers ───────────────────────────────────────────────────
+BRAVE_SEARCH_API_KEY:
+  op_item: "Brave Search API Key Dev"
+  op_vault: DevOps
+
+EXA_API_KEY:
+  op_item: "Exa API Key Dev"
+  op_vault: DevOps
+
+KAGI_API_KEY:
+  op_item: "kagi API Key Dev"
+  op_vault: DevOps
+
+PERPLEXITY_API_KEY:
+  op_item: "Perplexity API Key Dev"
+  op_vault: DevOps
+
+SERPAPI_API_KEY:
+  op_item: "SerpApi API Key Dev"
+  op_vault: DevOps
+
+TAVILY_API_KEY:
+  op_item: "Taviliy API Key Dev"
+  op_vault: DevOps
+
+# ── AI infrastructure ─────────────────────────────────────────────────────────
+CEREBRAS_API_KEY:
+  op_item: "Cerebras API Key Dev"
+  op_vault: DevOps
+
+GROQ_API_KEY:
+  op_item: "Groq API Key Dev"
+  op_vault: DevOps
+
+MISTRAL_API_KEY:
+  op_item: "Mistral API Key Dev"
+  op_vault: DevOps
+
+SAMBANOVA_API_KEY:
+  op_item: "Sambanova API Token Dev"
+  op_field: "api token"
+  op_vault: DevOps
+
+STEPFUN_API_KEY:
+  op_item: "StepFun API Key Dev"
+  op_field: "interface key"
+  op_vault: DevOps
+
+REPLICATE_API_KEY:
+  op_item: "Replicate API Token Dev"
+  op_field: "api token"
+  op_vault: DevOps
+
+# ── Memory & tooling ──────────────────────────────────────────────────────────
+MEM0_API_KEY:
+  op_item: "Mem0 API Key Dev"
+  op_vault: DevOps
+
+QDRANT_API_KEY:
+  op_item: "Qdrant API Key Dev"
+  op_vault: DevOps
+
+SUPERMEMORY_CC_API_KEY:
+  op_item: "Supermemory API Key Dev"
+  op_vault: DevOps
+
+TINFOIL_API_KEY:
+  op_item: "Tinfoil API Key Dev"
+  op_vault: DevOps
+
+UNBOUND_API_KEY:
+  op_item: "Unbound API Key Dev"
+  op_vault: DevOps
+
+# ── Media & generation ────────────────────────────────────────────────────────
+COMFYUI_API_KEY:
+  op_item: "ComfyUI API Key Dev"
+  op_vault: DevOps
+
+DASHSCOPE_API_KEY:
+  op_item: "Alibaba Dashscope API Key Dev"
+  op_vault: DevOps
+
+ELEVENLABS_API_KEY:
+  op_item: "ElevenLabs API Key Dev"
+  op_vault: DevOps
+
+FAL_KEY:
+  op_item: "FAL API Key Dev"
+  op_vault: DevOps
+
+LAMINI_API_TOKEN:
+  op_item: "LAMINI API Token Dev"
+  op_field: "api token"
+  op_vault: DevOps
+
+PEXELS_API_KEY:
+  op_item: "Pexels API Key Dev"
+  op_vault: DevOps
+
+# ── Web & browser ─────────────────────────────────────────────────────────────
+BROWSERBASE_API_KEY:
+  op_item: "Browser Base API Key Dev"
+  op_vault: DevOps
+
+BROWSERBASE_PROJECT_ID:
+  op_item: "Browser Base API Key Dev"
+  op_field: "project id"
+  op_vault: DevOps
+
+BROWSERLESS_API_TOKEN:
+  op_item: "Browserless API Key Dev"
+  op_vault: DevOps  # field is "api key" — mulmocast names it token not key
+
+FIRECRAWL_API_KEY:
+  op_item: "firecrawl API Key Dev"
+  op_vault: DevOps
+
+MCPO_API_KEY:
+  op_item: "MCPO Server API Key Local"
+  op_vault: DevOps
+
+# ── Open WebUI ────────────────────────────────────────────────────────────────
+WEBUI_API_KEY:
+  op_item: "Open WebUI API Key Dev"
+  op_vault: DevOps
+
+WEBUI_SECRET_KEY:
+  op_item: "Open WebUI Secret Key Dev"
+  op_field: "secret key"
+  op_vault: DevOps
+
+# ── Infra & services ──────────────────────────────────────────────────────────
+SUPERSET_SECRET_KEY:
+  op_item: "Apache Superset Secret Dev"
+  op_vault: DevOps
+
+SLASHGPT_ENV_WEBPILOT_UID:
+  op_item: "Webpilot UID Dev"
+  op_field: "key"
+  op_vault: DevOps
+
+# ── Bots & messaging ──────────────────────────────────────────────────────────
+DISCORD_BOT_TOKEN:
+  op_item: "Discord Bot Token Dev"
+  op_field: "api token"
+  op_vault: Private
+
+TELEGRAM_BOT_TOKEN:
+  op_item: "Telegram Bot Token Dev"
+  op_field: "api token"
+  op_vault: Private
+
+# ── Developer tokens ──────────────────────────────────────────────────────────
+HF_TOKEN:
+  op_item: "Hugging Face API Token Dev"
+  op_field: "user access token"
+  op_vault: DevOps
+
+GITHUB_TOKEN_CLASSIC:
+  op_item: "GitHub Personal Access Token Classic"
+  op_field: "token"  # must be named 'token' for op plugin gh compatibility
+  op_vault: Private
+
+SKILL_SIGNER_KEY_ID:
+  op_item: "GPG Skill Signer"
+  op_field: "Key Id"
+  op_vault: DevOps
+
+# ── Aliases (equivalent_of — written outside op inject block) ─────────────────
+ZHIPU_API_KEY:
+  equivalent_of: Z_AI_API_KEY
+
+GOOGLE_AI_API_KEY:
+  equivalent_of: GEMINI_API_KEY
+  # used by zed; disabled by default — uncomment if needed
+  disabled: true
+
+# ── Disabled / commented out ──────────────────────────────────────────────────
+# CIVITAI_TOKEN:
+#   op_item: "Civitai API Key Dev"
+#   disabled: true
+
+# DIGITALOCEAN_ACCESS_TOKEN:
+#   op_item: "DigitalOcean Personal Access Token"
+#   op_vault: Private
+#   disabled: true
+
+# GITHUB_TOKEN:
+#   op_item: "GitHub Personal Access Token"
+#   disabled: true  # do not use — overrides gh auth login
+
+# LOCALSTACK_API_KEY:
+#   op_item: "LocalStack API Key"
+#   disabled: true
+
+# GOOGLE_AI_API_KEY:  # used by zed
+#   equivalent_of: GEMINI_API_KEY
+#   disabled: true

--- a/include.ai.mk
+++ b/include.ai.mk
@@ -362,7 +362,7 @@ ai-p:
 # ── Public entry points ───────────────────────────────────────────────────────
 
 ## ai: start full sidecar stack — cloud + local GPU, all models available
-## See all available models after start: make ai-help
+## See all available models (cloud + local) after start: make ai-help
 ## Sidecars: postgres redis mlflow litellm temporal set-gpu-max-memory lls-start
 ## (ai-local was merged into ai — one stack serves all models)
 .PHONY: ai ai-local
@@ -370,40 +370,43 @@ ai ai-local: mlflow-start postgres redis mlflow litellm temporal set-gpu-max-mem
 	@$(MAKE) --no-print-directory ai-help
 	@$(MAKE) --no-print-directory ai-warn-bridges
 
-## ai-help: show available models — static cloud providers + dynamic lls/ollama from live config
+## ai-help: show available models — live cloud cache + dynamic lls/ollama
+## Cloud models come from ~/.cache/tne/model-ids.yaml (refresh: make ai-refresh-models)
 .PHONY: ai-help
 ai-help:
 	@echo ""
 	@echo "  Stack ready. Run your AI harness (MODEL= optional):"
 	@echo ""
-	@echo "  ── Cloud / Subscription ─────────────────────────────────────────────────"
+	@echo "  ── Cloud (API keys — refresh: make ai-refresh-models) ───────────────────"
 	@echo "    make ai-run                               # claude Max plan (default)"
-	@yq '.model_list[].model_name' "$(LITELLM_CFG)" 2>/dev/null \
-		| grep -v '^lls/' | grep -v '^lms/' | sort \
-		| while IFS= read -r name; do printf '    make ai-run MODEL=%-36s\n' "$$name"; done
+	@bash -c 'source "$(LIB_UTIL)" && source "$(LIB_AI)" && ai_resolve_model_names 2>/dev/null; \
+		env | grep "^AI_MODEL_.*_LATEST=" | sort \
+		| while IFS="=" read -r var val; do \
+			provider=$$(echo "$$var" | sed "s/^AI_MODEL_//;s/_LATEST$$//;s/_/./g" | tr "[:upper:]" "[:lower:]"); \
+			printf "    make ai-run MODEL=%-36s# %s\n" "$$val" "$$provider"; \
+		done'
 	@echo ""
 	@echo "  ── Local GPU (llama-server) ─────────────────────────────────────────────"
 	@if nc -z localhost $(LLS_PORT) 2>/dev/null; then \
 		curl -sf http://localhost:$(LLS_PORT)/v1/models 2>/dev/null \
-		| python3 -c "import sys,json; [print('    make ai-run MODEL=lls/{:<28} # FREE'.format(m['id'])) \
-		  for m in json.load(sys.stdin).get('data',[])]" 2>/dev/null \
-		|| yq '.model_list[].model_name' "$(LITELLM_CFG)" 2>/dev/null | grep '^lls' | sort | \
-		   while IFS= read -r name; do printf '    make ai-run MODEL=%-36s # FREE\n' "$$name"; done; \
+		| yq -p json '.data[].id' 2>/dev/null \
+		| while IFS= read -r id; do printf '    make ai-run MODEL=lls/%-28s # FREE\n' "$$id"; done \
+		|| echo "    (lls running but models unavailable)"; \
 	else \
-		yq '.model_list[].model_name' "$(LITELLM_CFG)" 2>/dev/null | grep '^lls' | sort | \
-		while IFS= read -r name; do printf '    make ai-run MODEL=%-36s # FREE (lls offline)\n' "$$name"; done; \
-		[ -z "$$(yq '.model_list[].model_name' "$(LITELLM_CFG)" 2>/dev/null | grep '^lls')" ] \
-		  && echo "    (no lls models in $(LITELLM_CFG))"; \
+		yq '.model_list[].model_name' "$(LITELLM_CFG)" 2>/dev/null | grep '^lls' | sort \
+		| while IFS= read -r name; do printf '    make ai-run MODEL=%-36s # FREE (lls offline)\n' "$$name"; done; \
+		[ -z "$$(yq '.model_list[].model_name' "$(LITELLM_CFG)" 2>/dev/null | grep -c '^lls')" ] \
+		  && echo "    (lls not running — start with: make lls-start)"; \
 	fi
 	@echo ""
 	@echo "  ── Ollama ───────────────────────────────────────────────────────────────"
 	@if nc -z localhost 11434 2>/dev/null; then \
 		curl -sf http://localhost:11434/api/tags 2>/dev/null \
-		| python3 -c "import sys,json; [print('    make ai-run MODEL=ollama/{:<24} # FREE'.format(m['name'])) \
-		  for m in json.load(sys.stdin).get('models',[])]" 2>/dev/null \
+		| yq -p json '.models[].name' 2>/dev/null \
+		| while IFS= read -r name; do printf '    make ai-run MODEL=ollama/%-28s # FREE\n' "$$name"; done \
 		|| echo "    (ollama running — run: ollama list)"; \
 	else \
-		echo "    (ollama not running — run: ollama serve)"; \
+		echo "    (ollama not running — start with: ollama serve)"; \
 	fi
 	@echo ""
 	@echo "  ── Batch (claude -p) ────────────────────────────────────────────────────"

--- a/include.ai.mk
+++ b/include.ai.mk
@@ -1095,6 +1095,23 @@ tika:
 comfy:
 	open -a "ComfyUI.app"
 
+LIB_AI      ?= $(WS_DIR)/git/src/lib/lib-ai.sh
+LIB_SECRETS ?= $(WS_DIR)/git/src/lib/lib-secrets.sh
+LIB_UTIL    ?= $(WS_DIR)/git/src/lib/lib-util.sh
+
+## ai-check-keys: curl each AI provider's /v1/models — reports valid/expired/unreachable
+.PHONY: ai-check-keys
+ai-check-keys:
+	@bash -c 'source "$(LIB_UTIL)" && source "$(LIB_AI)" && ai_check_api_keys'
+
+## ai-refresh-models: query providers for latest model IDs, patch CCR + LiteLLM configs
+## Uses 7-day cache (~/.cache/tne/model-ids.yaml). Force refresh: make ai-refresh-models AI_MODEL_CACHE_TTL_DAYS=0
+.PHONY: ai-refresh-models
+ai-refresh-models:
+	@bash -c 'source "$(LIB_UTIL)" && source "$(LIB_AI)" && \
+		ai_resolve_model_names && ai_patch_ccr_config && ai_patch_litellm_config && \
+		echo "Done — restart ccr and litellm to pick up changes"'
+
 # ## mcpo: MCP → OpenAPI adapter (exposes MCP servers as REST endpoints)
 # MCPO_PORT    ?= 8001
 # MCPO_CONFIG  ?= $(HOME)/.config/mcp/claude-desktop.json

--- a/include.ai.mk
+++ b/include.ai.mk
@@ -854,9 +854,13 @@ ai-install:
 	_schema=$$_venv/lib/python*/site-packages/litellm/proxy/schema.prisma; \
 	$$_venv/bin/python -m prisma generate --schema $$_schema
 	mkdir -p $$(dirname $(PRISMA_STAMP)) && touch $(PRISMA_STAMP)
-	echo "==> brew services: start redis + postgresql"
+	echo "==> brew: tne-engine-worker (persistent Temporal worker — r-cto-dev129)"
+	brew tap tne-ai/tne-tap 2>/dev/null || true
+	brew list tne-engine-worker &>/dev/null 2>&1 || brew install tne-ai/tne-tap/tne-engine-worker 2>/dev/null || echo "  (tne-engine-worker install failed — worker will start transiently at session start)"
+	echo "==> brew services: start redis + postgresql + tne-engine-worker"
 	brew services start redis 2>/dev/null || true
 	brew services start postgresql@17 2>/dev/null || brew services start postgresql 2>/dev/null || true
+	brew list tne-engine-worker &>/dev/null 2>&1 && brew services start tne-engine-worker 2>/dev/null || true
 	echo "==> creating litellm database"
 	createdb $(LITELLM_DB) 2>/dev/null || true
 	echo "==> litellm config"
@@ -989,6 +993,10 @@ temporal:
 	mkdir -p "$(dir $(TEMPORAL_DB))"
 	$(call start_server,$(TEMPORAL_PORT),temporal server start-dev --db-filename $(TEMPORAL_DB) --ui-port $(TEMPORAL_UI_PORT))
 	$(call check_port,$(TEMPORAL_PORT))
+	@# tne-engine-worker: start via brew services if formula installed (r-cto-dev129)
+	@brew list tne-engine-worker &>/dev/null 2>&1 \
+		&& { pgrep -f "engine.temporal_worker" >/dev/null 2>&1 || brew services start tne-engine-worker 2>/dev/null || true; } \
+		|| echo "  (tne-engine-worker formula not installed — run: make ai-install)"
 
 # ktap is tne-plugin-only — override in project Makefile if needed
 # ## ktap: KTAP knowledge graph viewer at http://localhost:$(KTAP_PORT)

--- a/lib-ai.sh
+++ b/lib-ai.sh
@@ -4,7 +4,7 @@
 ## AI provider utilities: API key freshness checks, model name resolution,
 ## and config patching for CCR + LiteLLM.
 ## Reads provider metadata from api-keys.yaml — never calls op or 1Password.
-## Requires: python3, curl. Source lib-secrets.sh first to populate env vars.
+## Requires: yq v4, curl. Source lib-secrets.sh first to populate env vars.
 
 lib_name="$(basename "${BASH_SOURCE%.*}")"
 lib_name="${lib_name//-/_}"
@@ -24,70 +24,27 @@ if eval "[[ -z \${$lib_name+x} ]]"; then
 		shift
 		local -a filter=("$@")
 
-		python3 - "$yaml_file" "${filter[@]}" <<'PYEOF'
-import sys
+		local key_filter=""
+		if [[ ${#filter[@]} -gt 0 ]]; then
+			local conditions
+			conditions=$(printf ' or .key == "%s"' "${filter[@]}")
+			key_filter="| select(${conditions# or })"
+		fi
 
-yaml_file = sys.argv[1]
-filter_vars = set(sys.argv[2:]) if len(sys.argv) > 2 else set()
-
-def parse_with_pyyaml(path):
-    import yaml
-    with open(path) as f:
-        return yaml.safe_load(f) or {}
-
-def parse_fallback(path):
-    data = {}
-    current_key = None
-    with open(path) as f:
-        for line in f:
-            stripped = line.rstrip()
-            if not stripped or stripped.lstrip().startswith('#'):
-                continue
-            if stripped and stripped[0] not in (' ', '\t') and stripped.endswith(':'):
-                current_key = stripped[:-1].strip()
-                data[current_key] = {}
-            elif current_key and stripped.startswith((' ', '\t')):
-                content = stripped.strip()
-                if ':' in content:
-                    k, _, v = content.partition(':')
-                    k = k.strip()
-                    v = v.strip().strip('"').strip("'")
-                    if '  #' in v:
-                        v = v[:v.index('  #')].strip()
-                    if v.lower() == 'true':
-                        v = True
-                    elif v.lower() == 'false':
-                        v = False
-                    data[current_key][k] = v
-    return data
-
-try:
-    data = parse_with_pyyaml(yaml_file)
-except ImportError:
-    data = parse_fallback(yaml_file)
-
-for env_var, cfg in data.items():
-    if not isinstance(cfg, dict):
-        continue
-    if cfg.get('disabled', False) is True:
-        continue
-    if filter_vars and env_var not in filter_vars:
-        continue
-    models_url = cfg.get('models_url', '')
-    if not models_url:
-        continue  # not an AI provider
-    print('\t'.join([
-        env_var,
-        models_url,
-        cfg.get('models_auth', 'bearer'),
-        cfg.get('models_auth_param', 'key'),
-        cfg.get('models_pattern', ''),
-        cfg.get('litellm_base', ''),
-        cfg.get('litellm_key_env', env_var),
-        cfg.get('litellm_model_prefix', 'openai/'),
-        cfg.get('ccr_provider', ''),
-    ]))
-PYEOF
+		yq e "to_entries | .[] ${key_filter}
+			| select(.value | type == \"!!map\")
+			| select(.value.disabled != true)
+			| select(.value.models_url != null)
+			| [.key,
+			   .value.models_url,
+			   (.value.models_auth // \"bearer\"),
+			   (.value.models_auth_param // \"key\"),
+			   (.value.models_pattern // \"\"),
+			   (.value.litellm_base // \"\"),
+			   (.value.litellm_key_env // .key),
+			   (.value.litellm_model_prefix // \"openai/\"),
+			   (.value.ccr_provider // \"\")]
+			| @tsv" "$yaml_file"
 	}
 
 	# ── ai_check_api_keys ─────────────────────────────────────────────────────────
@@ -164,7 +121,6 @@ PYEOF
 		local ttl="$_AI_MODEL_CACHE_TTL_DAYS"
 		local cache_fresh=false
 
-		# Check cache freshness
 		if [[ -f "$cache" ]]; then
 			local cache_age_days
 			cache_age_days=$(python3 -c "
@@ -176,12 +132,10 @@ print(int(age / 86400))
 		fi
 
 		if $cache_fresh; then
-			# Load from cache
 			_ai_load_model_cache "$cache"
 			return 0
 		fi
 
-		# Fetch live and build new cache
 		mkdir -p "$(dirname "$cache")"
 		local -a cache_lines=()
 		local _providers
@@ -225,14 +179,12 @@ except Exception:
 			local provider_key
 			provider_key=$(echo "${ccr_provider:-$env_var}" | tr '[:lower:].' '[:upper:]_' | tr -c 'A-Z0-9_' '_')
 
-			# Set vars in current shell
 			export "AI_MODEL_${provider_key}_LATEST=$latest"
 			export "AI_MODEL_${provider_key}_IDS=$(tr '\n' ':' <<<"$ids" | sed 's/:$//')"
 
 			cache_lines+=("${provider_key}:${latest}:$(tr '\n' ',' <<<"$ids" | sed 's/,$//')")
 		done <<<"$_providers"
 
-		# Write cache
 		printf '%s\n' "${cache_lines[@]}" >"$cache"
 	}
 
@@ -260,7 +212,6 @@ except Exception:
 		local _providers
 		_providers=$(_ai_parse_providers "$_SECRETS_YAML") || return 1
 
-		# Build provider→ids map from resolved vars
 		local patch_json="{}"
 		while IFS=$'\t' read -r env_var _url _auth _param _pattern \
 			_base _key _prefix ccr_provider; do
@@ -282,7 +233,6 @@ a.update(b); print(json.dumps(a))
 " "$patch_json" "$ids_json" 2>/dev/null) || continue
 		done <<<"$_providers"
 
-		# Apply patch to CCR config
 		cp "$cfg" "${cfg}.bak.$(date +%Y%m%d)"
 		python3 - "$cfg" "$patch_json" <<'PYEOF'
 import sys, json
@@ -326,7 +276,7 @@ PYEOF
 			[[ -z "${!latest_var:-}" ]] && continue
 
 			local model_id="${litellm_prefix}${!latest_var}"
-			local model_name="${!latest_var,,}" # lowercase for model_name
+			local model_name="${!latest_var,,}"
 
 			python3 - "$cfg" "$model_name" "$model_id" "$litellm_base" "$litellm_key_env" <<'PYEOF'
 import sys, re
@@ -336,7 +286,6 @@ cfg_path, model_name, model_id, api_base, key_env = sys.argv[1:6]
 with open(cfg_path) as f:
     content = f.read()
 
-# Build replacement entry
 entry = (
     f"  - model_name: {model_name}\n"
     f"    litellm_params:\n"
@@ -345,12 +294,10 @@ entry = (
     f"      api_key: os.environ/{key_env}\n"
 )
 
-# Replace existing entry for this model_name, or append
 pattern = rf"  - model_name: {re.escape(model_name)}\n(?:    [^\n]+\n)*"
 if re.search(pattern, content):
     content = re.sub(pattern, entry, content)
 else:
-    # Append before end of model_list or at end of file
     if 'model_list:' in content:
         content = content.rstrip() + '\n' + entry
     else:

--- a/lib-ai.sh
+++ b/lib-ai.sh
@@ -1,0 +1,366 @@
+#!/usr/bin/env bash
+# vim: ai:sw=4:ts=4:noet
+##
+## AI provider utilities: API key freshness checks, model name resolution,
+## and config patching for CCR + LiteLLM.
+## Reads provider metadata from api-keys.yaml — never calls op or 1Password.
+## Requires: python3, curl. Source lib-secrets.sh first to populate env vars.
+
+lib_name="$(basename "${BASH_SOURCE%.*}")"
+lib_name="${lib_name//-/_}"
+if eval "[[ -z \${$lib_name+x} ]]"; then
+	eval "$lib_name=true"
+
+	_SECRETS_YAML="${SECRETS_YAML:-$(dirname "${BASH_SOURCE[0]}")/api-keys.yaml}"
+	_AI_MODEL_CACHE="${AI_MODEL_CACHE:-$HOME/.cache/tne/model-ids.yaml}"
+	_AI_MODEL_CACHE_TTL_DAYS="${AI_MODEL_CACHE_TTL_DAYS:-7}"
+
+	# ── YAML provider reader ──────────────────────────────────────────────────────
+	# Parse api-keys.yaml for AI provider fields only.
+	# Prints TSV: env_var models_url models_auth models_auth_param models_pattern
+	#             litellm_base litellm_key_env litellm_model_prefix ccr_provider
+	_ai_parse_providers() {
+		local yaml_file="${1:-$_SECRETS_YAML}"
+		shift
+		local -a filter=("$@")
+
+		python3 - "$yaml_file" "${filter[@]}" <<'PYEOF'
+import sys
+
+yaml_file = sys.argv[1]
+filter_vars = set(sys.argv[2:]) if len(sys.argv) > 2 else set()
+
+def parse_with_pyyaml(path):
+    import yaml
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+def parse_fallback(path):
+    data = {}
+    current_key = None
+    with open(path) as f:
+        for line in f:
+            stripped = line.rstrip()
+            if not stripped or stripped.lstrip().startswith('#'):
+                continue
+            if stripped and stripped[0] not in (' ', '\t') and stripped.endswith(':'):
+                current_key = stripped[:-1].strip()
+                data[current_key] = {}
+            elif current_key and stripped.startswith((' ', '\t')):
+                content = stripped.strip()
+                if ':' in content:
+                    k, _, v = content.partition(':')
+                    k = k.strip()
+                    v = v.strip().strip('"').strip("'")
+                    if '  #' in v:
+                        v = v[:v.index('  #')].strip()
+                    if v.lower() == 'true':
+                        v = True
+                    elif v.lower() == 'false':
+                        v = False
+                    data[current_key][k] = v
+    return data
+
+try:
+    data = parse_with_pyyaml(yaml_file)
+except ImportError:
+    data = parse_fallback(yaml_file)
+
+for env_var, cfg in data.items():
+    if not isinstance(cfg, dict):
+        continue
+    if cfg.get('disabled', False) is True:
+        continue
+    if filter_vars and env_var not in filter_vars:
+        continue
+    models_url = cfg.get('models_url', '')
+    if not models_url:
+        continue  # not an AI provider
+    print('\t'.join([
+        env_var,
+        models_url,
+        cfg.get('models_auth', 'bearer'),
+        cfg.get('models_auth_param', 'key'),
+        cfg.get('models_pattern', ''),
+        cfg.get('litellm_base', ''),
+        cfg.get('litellm_key_env', env_var),
+        cfg.get('litellm_model_prefix', 'openai/'),
+        cfg.get('ccr_provider', ''),
+    ]))
+PYEOF
+	}
+
+	# ── ai_check_api_keys ─────────────────────────────────────────────────────────
+	# Curl each provider's models_url in parallel; report 200/401/403/timeout.
+	# Only checks keys that are currently set in the environment.
+	# Args: optional env var names to check (default: all with models_url)
+	# Completes in <10s (3s connect timeout, parallel subshells).
+	ai_check_api_keys() {
+		local -a vars=("$@")
+		local _providers
+		_providers=$(_ai_parse_providers "$_SECRETS_YAML" "${vars[@]}") || return 1
+
+		local -a pids=()
+		local -a results=()
+		local tmpdir
+		tmpdir=$(mktemp -d)
+
+		while IFS=$'\t' read -r env_var models_url models_auth models_auth_param _rest; do
+			[[ -z "$env_var" || -z "${!env_var:-}" ]] && continue
+			local result_file="$tmpdir/$env_var"
+			(
+				if [[ "$models_auth" == "query" ]]; then
+					code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 \
+						"${models_url}?${models_auth_param}=${!env_var}")
+				else
+					code=$(curl -s -o /dev/null -w "%{http_code}" --connect-timeout 3 \
+						-H "Authorization: Bearer ${!env_var}" "$models_url")
+				fi
+				echo "$code" >"$result_file"
+			) &
+			pids+=($!)
+			results+=("$env_var $result_file")
+		done <<<"$_providers"
+
+		for pid in "${pids[@]}"; do wait "$pid" 2>/dev/null || true; done
+
+		local any_fail=0
+		for entry in "${results[@]}"; do
+			local ev rf code
+			ev="${entry%% *}"
+			rf="${entry#* }"
+			code=$(cat "$rf" 2>/dev/null || echo "000")
+			case "$code" in
+			200) echo "$ev: valid" ;;
+			401)
+				echo "$ev: EXPIRED or INVALID (401) — refresh the key" >&2
+				any_fail=1
+				;;
+			403)
+				echo "$ev: FORBIDDEN (403) — wrong key or no access" >&2
+				any_fail=1
+				;;
+			000)
+				echo "$ev: unreachable — network/DNS failure" >&2
+				any_fail=1
+				;;
+			*)
+				echo "$ev: unexpected HTTP $code" >&2
+				any_fail=1
+				;;
+			esac
+		done
+		rm -rf "$tmpdir"
+		return "$any_fail"
+	}
+
+	# ── ai_resolve_model_names ────────────────────────────────────────────────────
+	# Query each provider's models_url, filter by models_pattern, cache results.
+	# Cache TTL: _AI_MODEL_CACHE_TTL_DAYS (default 7).
+	# Sets per-provider vars: AI_MODEL_<PROVIDER>_LATEST and AI_MODEL_<PROVIDER>_IDS
+	# Provider name derived from ccr_provider field (uppercased, non-alnum→_).
+	ai_resolve_model_names() {
+		local cache="$_AI_MODEL_CACHE"
+		local ttl="$_AI_MODEL_CACHE_TTL_DAYS"
+		local cache_fresh=false
+
+		# Check cache freshness
+		if [[ -f "$cache" ]]; then
+			local cache_age_days
+			cache_age_days=$(python3 -c "
+import os, time
+age = time.time() - os.path.getmtime('$cache')
+print(int(age / 86400))
+" 2>/dev/null || echo 999)
+			[[ "$cache_age_days" -lt "$ttl" ]] && cache_fresh=true
+		fi
+
+		if $cache_fresh; then
+			# Load from cache
+			_ai_load_model_cache "$cache"
+			return 0
+		fi
+
+		# Fetch live and build new cache
+		mkdir -p "$(dirname "$cache")"
+		local -a cache_lines=()
+		local _providers
+		_providers=$(_ai_parse_providers "$_SECRETS_YAML") || return 1
+
+		while IFS=$'\t' read -r env_var models_url models_auth models_auth_param \
+			models_pattern _litellm_base _litellm_key _litellm_prefix ccr_provider; do
+			[[ -z "$env_var" || -z "${!env_var:-}" ]] && continue
+
+			local json
+			if [[ "$models_auth" == "query" ]]; then
+				json=$(curl -sf --connect-timeout 5 \
+					"${models_url}?${models_auth_param}=${!env_var}" 2>/dev/null)
+			else
+				json=$(curl -sf --connect-timeout 5 \
+					-H "Authorization: Bearer ${!env_var}" "$models_url" 2>/dev/null)
+			fi
+			[[ -z "$json" ]] && continue
+
+			local ids
+			ids=$(echo "$json" | python3 -c "
+import sys, json, re
+pattern = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+    items = data.get('data', data.get('models', []))
+    ids = []
+    for m in items:
+        mid = m.get('id') or m.get('name', '')
+        if mid and (not pattern or re.search(pattern, mid)):
+            ids.append(mid)
+    ids.sort()
+    print('\n'.join(ids))
+except Exception:
+    pass
+" "$models_pattern" 2>/dev/null)
+			[[ -z "$ids" ]] && continue
+
+			local latest
+			latest=$(tail -1 <<<"$ids")
+			local provider_key
+			provider_key=$(echo "${ccr_provider:-$env_var}" | tr '[:lower:].' '[:upper:]_' | tr -c 'A-Z0-9_' '_')
+
+			# Set vars in current shell
+			export "AI_MODEL_${provider_key}_LATEST=$latest"
+			export "AI_MODEL_${provider_key}_IDS=$(tr '\n' ':' <<<"$ids" | sed 's/:$//')"
+
+			cache_lines+=("${provider_key}:${latest}:$(tr '\n' ',' <<<"$ids" | sed 's/,$//')")
+		done <<<"$_providers"
+
+		# Write cache
+		printf '%s\n' "${cache_lines[@]}" >"$cache"
+	}
+
+	# Load model vars from cache file (internal helper)
+	_ai_load_model_cache() {
+		local cache="$1"
+		while IFS=: read -r provider_key latest ids_csv; do
+			[[ -z "$provider_key" ]] && continue
+			export "AI_MODEL_${provider_key}_LATEST=$latest"
+			export "AI_MODEL_${provider_key}_IDS=${ids_csv//,/:}"
+		done <"$cache"
+	}
+
+	# ── ai_patch_ccr_config ───────────────────────────────────────────────────────
+	# Rewrite model arrays in ~/.claude-code-router/config.json using resolved IDs.
+	# Requires ai_resolve_model_names to have run first.
+	# Creates a dated backup before writing.
+	ai_patch_ccr_config() {
+		local cfg="${CCR_CONFIG:-$HOME/.claude-code-router/config.json}"
+		[[ -f "$cfg" ]] || {
+			echo "ai_patch_ccr_config: not found: $cfg" >&2
+			return 1
+		}
+
+		local _providers
+		_providers=$(_ai_parse_providers "$_SECRETS_YAML") || return 1
+
+		# Build provider→ids map from resolved vars
+		local patch_json="{}"
+		while IFS=$'\t' read -r env_var _url _auth _param _pattern \
+			_base _key _prefix ccr_provider; do
+			[[ -z "$ccr_provider" ]] && continue
+			local provider_key
+			provider_key=$(echo "$ccr_provider" | tr '[:lower:].' '[:upper:]_' | tr -c 'A-Z0-9_' '_')
+			local ids_var="AI_MODEL_${provider_key}_IDS"
+			[[ -z "${!ids_var:-}" ]] && continue
+			local ids_json
+			ids_json=$(python3 -c "
+import json, sys
+ids = sys.argv[1].split(':')
+print(json.dumps({'${ccr_provider}': ids}))
+" "${!ids_var}" 2>/dev/null) || continue
+			patch_json=$(python3 -c "
+import json, sys
+a, b = json.loads(sys.argv[1]), json.loads(sys.argv[2])
+a.update(b); print(json.dumps(a))
+" "$patch_json" "$ids_json" 2>/dev/null) || continue
+		done <<<"$_providers"
+
+		# Apply patch to CCR config
+		cp "$cfg" "${cfg}.bak.$(date +%Y%m%d)"
+		python3 - "$cfg" "$patch_json" <<'PYEOF'
+import sys, json
+cfg_path, patch_json = sys.argv[1], sys.argv[2]
+patch = json.loads(patch_json)
+with open(cfg_path) as f:
+    cfg = json.load(f)
+for provider in cfg.get('Providers', []):
+    name = provider.get('name', '')
+    if name in patch:
+        provider['models'] = patch[name]
+with open(cfg_path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+    f.write('\n')
+PYEOF
+		echo "ai_patch_ccr_config: patched $cfg"
+	}
+
+	# ── ai_patch_litellm_config ───────────────────────────────────────────────────
+	# Rewrite model_list entries in ~/.config/litellm/config.yaml.
+	# Requires ai_resolve_model_names to have run first.
+	# Creates a dated backup before writing.
+	ai_patch_litellm_config() {
+		local cfg="${LITELLM_CONFIG:-$HOME/.config/litellm/config.yaml}"
+		[[ -f "$cfg" ]] || {
+			echo "ai_patch_litellm_config: not found: $cfg" >&2
+			return 1
+		}
+
+		local _providers
+		_providers=$(_ai_parse_providers "$_SECRETS_YAML") || return 1
+
+		cp "$cfg" "${cfg}.bak.$(date +%Y%m%d)"
+
+		while IFS=$'\t' read -r env_var _url _auth _param _pattern \
+			litellm_base litellm_key_env litellm_prefix ccr_provider; do
+			[[ -z "$litellm_base" ]] && continue
+			local provider_key
+			provider_key=$(echo "${ccr_provider:-$env_var}" | tr '[:lower:].' '[:upper:]_' | tr -c 'A-Z0-9_' '_')
+			local latest_var="AI_MODEL_${provider_key}_LATEST"
+			[[ -z "${!latest_var:-}" ]] && continue
+
+			local model_id="${litellm_prefix}${!latest_var}"
+			local model_name="${!latest_var,,}" # lowercase for model_name
+
+			python3 - "$cfg" "$model_name" "$model_id" "$litellm_base" "$litellm_key_env" <<'PYEOF'
+import sys, re
+
+cfg_path, model_name, model_id, api_base, key_env = sys.argv[1:6]
+
+with open(cfg_path) as f:
+    content = f.read()
+
+# Build replacement entry
+entry = (
+    f"  - model_name: {model_name}\n"
+    f"    litellm_params:\n"
+    f"      model: {model_id}\n"
+    f"      api_base: {api_base}\n"
+    f"      api_key: os.environ/{key_env}\n"
+)
+
+# Replace existing entry for this model_name, or append
+pattern = rf"  - model_name: {re.escape(model_name)}\n(?:    [^\n]+\n)*"
+if re.search(pattern, content):
+    content = re.sub(pattern, entry, content)
+else:
+    # Append before end of model_list or at end of file
+    if 'model_list:' in content:
+        content = content.rstrip() + '\n' + entry
+    else:
+        content += f"\nmodel_list:\n{entry}"
+
+with open(cfg_path, 'w') as f:
+    f.write(content)
+PYEOF
+		done <<<"$_providers"
+		echo "ai_patch_litellm_config: patched $cfg"
+	}
+
+fi

--- a/lib-secrets.sh
+++ b/lib-secrets.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# vim: ai:sw=4:ts=4:noet
+##
+## 1Password API key loading from api-keys.yaml.
+## Generic — no AI-provider logic. Source before lib-ai.sh.
+## Requires: op CLI (1Password v2), python3
+
+lib_name="$(basename "${BASH_SOURCE%.*}")"
+lib_name="${lib_name//-/_}"
+if eval "[[ -z \${$lib_name+x} ]]"; then
+	eval "$lib_name=true"
+
+	_SECRETS_YAML="${SECRETS_YAML:-$(dirname "${BASH_SOURCE[0]}")/api-keys.yaml}"
+
+	# ── YAML parser ───────────────────────────────────────────────────────────────
+	# Parses api-keys.yaml; prints TSV rows to stdout.
+	# Columns: env_var op_item op_field op_vault disabled_by equivalent_of
+	# Uses PyYAML when available; falls back to a line-by-line state machine.
+	# Args: [yaml_file] [env_var_filter...]
+	_secrets_parse_yaml() {
+		local yaml_file="${1:-$_SECRETS_YAML}"
+		shift
+		local -a filter=("$@")
+
+		python3 - "$yaml_file" "${filter[@]}" <<'PYEOF'
+import sys
+
+yaml_file = sys.argv[1]
+filter_vars = set(sys.argv[2:]) if len(sys.argv) > 2 else set()
+
+def parse_with_pyyaml(path):
+    import yaml
+    with open(path) as f:
+        return yaml.safe_load(f) or {}
+
+def parse_fallback(path):
+    data = {}
+    current_key = None
+    with open(path) as f:
+        for line in f:
+            stripped = line.rstrip()
+            if not stripped or stripped.lstrip().startswith('#'):
+                continue
+            if stripped[0] not in (' ', '\t') and stripped.endswith(':'):
+                current_key = stripped[:-1].strip()
+                data[current_key] = {}
+            elif current_key and stripped.startswith((' ', '\t')):
+                content = stripped.strip()
+                if ':' in content:
+                    k, _, v = content.partition(':')
+                    k = k.strip()
+                    v = v.strip().strip('"').strip("'")
+                    if '  #' in v:
+                        v = v[:v.index('  #')].strip()
+                    if v.lower() == 'true':
+                        v = True
+                    elif v.lower() == 'false':
+                        v = False
+                    data[current_key][k] = v
+    return data
+
+try:
+    data = parse_with_pyyaml(yaml_file)
+except ImportError:
+    data = parse_fallback(yaml_file)
+
+for env_var, cfg in data.items():
+    if not isinstance(cfg, dict):
+        continue
+    if cfg.get('disabled', False) is True:
+        continue
+    if filter_vars and env_var not in filter_vars:
+        continue
+    op_item     = cfg.get('op_item', '')
+    op_field    = cfg.get('op_field', 'api key')
+    op_vault    = cfg.get('op_vault', 'DevOps')
+    disabled_by = cfg.get('disabled_by', '')
+    equivalent  = cfg.get('equivalent_of', '')
+    # skip bare stubs with neither op_item nor equivalent
+    if not op_item and not equivalent:
+        continue
+    print('\t'.join([env_var, op_item, op_field, op_vault, str(disabled_by or ''), str(equivalent or '')]))
+PYEOF
+	}
+
+	# ── op_load_api_keys ──────────────────────────────────────────────────────────
+	# Write op:// references for each key into a shell profile, or export directly.
+	# Skips entries with equivalent_of — use op_write_equivalents for those.
+	#
+	# Usage: op_load_api_keys [profile_file] [env_var...]
+	#   profile_file  — path containing / ; file to append lines to (default: stdout)
+	#   env_var...    — optional filter; loads all non-disabled keys if omitted
+	#
+	# SECRETS_EXPORT_DIRECT=true: calls `op item get` and exports to current shell.
+	# Default: writes `export VAR=op://Vault/Item/Field` for use inside op inject.
+	op_load_api_keys() {
+		local profile_file=""
+		local -a filter_vars=()
+
+		if [[ $# -gt 0 && "$1" == */* ]]; then
+			profile_file="$1"
+			shift
+		fi
+		filter_vars=("$@")
+
+		local _out
+		_out=$(_secrets_parse_yaml "$_SECRETS_YAML" "${filter_vars[@]}") || {
+			echo "op_load_api_keys: failed to parse $_SECRETS_YAML" >&2
+			return 1
+		}
+
+		while IFS=$'\t' read -r env_var op_item op_field op_vault disabled_by equivalent; do
+			[[ -z "$env_var" ]] && continue
+			# equivalents go in op_write_equivalents, not here
+			[[ -n "$equivalent" ]] && continue
+			[[ -z "$op_item" ]] && continue
+
+			local op_ref="op://${op_vault}/${op_item}/${op_field}"
+
+			if [[ "${SECRETS_EXPORT_DIRECT:-false}" == "true" ]]; then
+				[[ -v "$env_var" ]] && continue
+				[[ -n "$disabled_by" && -n "${!disabled_by:-}" ]] && continue
+				local val
+				val=$(op item get "$op_item" --fields "label=$op_field" \
+					--vault "$op_vault" --reveal 2>/dev/null) || {
+					echo "op_load_api_keys: warning — could not get $env_var" >&2
+					continue
+				}
+				export "$env_var=$val"
+			else
+				# Profile injection — write op:// reference
+				local line="[[ -v ${env_var} ]] || export ${env_var}=${op_ref}"
+				if [[ -n "$disabled_by" ]]; then
+					line="if [[ ! -v ${disabled_by} ]]; then ${line}; fi"
+				fi
+				if [[ -n "$profile_file" ]]; then
+					printf '%s\n' "$line" >>"$profile_file"
+				else
+					printf '%s\n' "$line"
+				fi
+			fi
+		done <<<"$_out"
+	}
+
+	# ── op_write_equivalents ──────────────────────────────────────────────────────
+	# Write VAR="$OTHER_VAR" lines for entries with equivalent_of set.
+	# These go OUTSIDE the op inject block in the shell profile.
+	# Args: [profile_file]
+	op_write_equivalents() {
+		local profile_file="${1:-}"
+		local _out
+		_out=$(_secrets_parse_yaml "$_SECRETS_YAML") || return 1
+
+		while IFS=$'\t' read -r env_var _item _field _vault _disabled_by equivalent; do
+			[[ -z "$equivalent" ]] && continue
+			local line="${env_var}=\"\$${equivalent}\""
+			if [[ -n "$profile_file" ]]; then
+				printf '%s\n' "$line" >>"$profile_file"
+			else
+				printf '%s\n' "$line"
+			fi
+		done <<<"$_out"
+	}
+
+	# ── op_check_key_set ──────────────────────────────────────────────────────────
+	# Warn for each env var that is unset or empty.
+	# Args: env var names to check (checks all with op_item if omitted)
+	# Returns 1 if any are missing, 0 if all set.
+	op_check_key_set() {
+		local -a vars=("$@")
+		local missing=0
+
+		if [[ ${#vars[@]} -eq 0 ]]; then
+			local _out
+			_out=$(_secrets_parse_yaml "$_SECRETS_YAML") || return 1
+			while IFS=$'\t' read -r env_var _rest; do
+				[[ -z "$env_var" ]] && continue
+				vars+=("$env_var")
+			done <<<"$_out"
+		fi
+
+		for v in "${vars[@]}"; do
+			if [[ -z "${!v:-}" ]]; then
+				echo "op_check_key_set: $v is not set" >&2
+				missing=1
+			fi
+		done
+		return "$missing"
+	}
+
+fi

--- a/lib-secrets.sh
+++ b/lib-secrets.sh
@@ -3,7 +3,7 @@
 ##
 ## 1Password API key loading from api-keys.yaml.
 ## Generic — no AI-provider logic. Source before lib-ai.sh.
-## Requires: op CLI (1Password v2), python3
+## Requires: op CLI (1Password v2), yq v4
 
 lib_name="$(basename "${BASH_SOURCE%.*}")"
 lib_name="${lib_name//-/_}"
@@ -15,72 +15,30 @@ if eval "[[ -z \${$lib_name+x} ]]"; then
 	# ── YAML parser ───────────────────────────────────────────────────────────────
 	# Parses api-keys.yaml; prints TSV rows to stdout.
 	# Columns: env_var op_item op_field op_vault disabled_by equivalent_of
-	# Uses PyYAML when available; falls back to a line-by-line state machine.
 	# Args: [yaml_file] [env_var_filter...]
 	_secrets_parse_yaml() {
 		local yaml_file="${1:-$_SECRETS_YAML}"
 		shift
 		local -a filter=("$@")
 
-		python3 - "$yaml_file" "${filter[@]}" <<'PYEOF'
-import sys
+		local key_filter=""
+		if [[ ${#filter[@]} -gt 0 ]]; then
+			local conditions
+			conditions=$(printf ' or .key == "%s"' "${filter[@]}")
+			key_filter="| select(${conditions# or })"
+		fi
 
-yaml_file = sys.argv[1]
-filter_vars = set(sys.argv[2:]) if len(sys.argv) > 2 else set()
-
-def parse_with_pyyaml(path):
-    import yaml
-    with open(path) as f:
-        return yaml.safe_load(f) or {}
-
-def parse_fallback(path):
-    data = {}
-    current_key = None
-    with open(path) as f:
-        for line in f:
-            stripped = line.rstrip()
-            if not stripped or stripped.lstrip().startswith('#'):
-                continue
-            if stripped[0] not in (' ', '\t') and stripped.endswith(':'):
-                current_key = stripped[:-1].strip()
-                data[current_key] = {}
-            elif current_key and stripped.startswith((' ', '\t')):
-                content = stripped.strip()
-                if ':' in content:
-                    k, _, v = content.partition(':')
-                    k = k.strip()
-                    v = v.strip().strip('"').strip("'")
-                    if '  #' in v:
-                        v = v[:v.index('  #')].strip()
-                    if v.lower() == 'true':
-                        v = True
-                    elif v.lower() == 'false':
-                        v = False
-                    data[current_key][k] = v
-    return data
-
-try:
-    data = parse_with_pyyaml(yaml_file)
-except ImportError:
-    data = parse_fallback(yaml_file)
-
-for env_var, cfg in data.items():
-    if not isinstance(cfg, dict):
-        continue
-    if cfg.get('disabled', False) is True:
-        continue
-    if filter_vars and env_var not in filter_vars:
-        continue
-    op_item     = cfg.get('op_item', '')
-    op_field    = cfg.get('op_field', 'api key')
-    op_vault    = cfg.get('op_vault', 'DevOps')
-    disabled_by = cfg.get('disabled_by', '')
-    equivalent  = cfg.get('equivalent_of', '')
-    # skip bare stubs with neither op_item nor equivalent
-    if not op_item and not equivalent:
-        continue
-    print('\t'.join([env_var, op_item, op_field, op_vault, str(disabled_by or ''), str(equivalent or '')]))
-PYEOF
+		yq e "to_entries | .[] ${key_filter}
+			| select(.value | type == \"!!map\")
+			| select(.value.disabled != true)
+			| select((.value.op_item != null) or (.value.equivalent_of != null))
+			| [.key,
+			   (.value.op_item // \"\"),
+			   (.value.op_field // \"api key\"),
+			   (.value.op_vault // \"DevOps\"),
+			   (.value.disabled_by // \"\"),
+			   (.value.equivalent_of // \"\")]
+			| @tsv" "$yaml_file"
 	}
 
 	# ── op_load_api_keys ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `make ai-install`: taps `tne-ai/tne-tap`, installs `tne-engine-worker` formula, starts it via `brew services`
- `make temporal`: after Temporal server starts, starts `tne-engine-worker` via `brew services` if formula is installed (r-cto-dev129)

## Why
Without this, the Temporal worker dies on logout. The brew formula makes it persistent. `make ai` → `temporal` now ensures the worker is also running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)