### PR TITLE
fix(ai-run): set ANTHROPIC_API_KEY and pass MINIMAX_PLAN_KEY to litellm

### DIFF
--- a/include.ai.mk
+++ b/include.ai.mk
@@ -274,6 +274,7 @@ litellm: litellm-check-version
 		QWEN_CODING_API_KEY="$${QWEN_CODING_API_KEY}" \
 		Z_AI_PLAN_KEY="$${Z_AI_PLAN_KEY}" \
 		MINIMAX_API_KEY="$${MINIMAX_API_KEY}" \
+		MINIMAX_PLAN_KEY="$${MINIMAX_PLAN_KEY}" \
 		OPENROUTER_API_KEY="$${OPENROUTER_API_KEY}" \
 		$$(command -v litellm || echo uvx litellm) --config $(LITELLM_CFG) --port $(LITELLM_PORT) --host 127.0.0.1)
 	$(call check_port,$(LITELLM_PORT))
@@ -352,13 +353,14 @@ ai-run:
 		|| echo "⚠️  lms load failed — model may already be loaded",)
 	ANTHROPIC_BASE_URL=http://localhost:$(LITELLM_PORT) \
 	OPENAI_BASE_URL=http://localhost:$(LITELLM_PORT) \
+	ANTHROPIC_API_KEY="$${LITELLM_MASTER_KEY}" \
 	ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: $${LITELLM_MASTER_KEY}" \
 	$(if $(MODEL),ANTHROPIC_CUSTOM_MODEL_OPTION=$(MODEL),) \
 	CLAUDE_CODE_ENABLE_TELEMETRY=1 \
 	OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
 	OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:$(MLFLOW_PORT) \
 	OTEL_EXPORTER_OTLP_HEADERS="x-mlflow-experiment-id=2" \
-	env -u CLAUDECODE $(HARNESS) $(if $(MODEL),--model $(MODEL),) $(HARNESS_ARGS)
+	env -u CLAUDECODE -u ANTHROPIC_MAX $(HARNESS) $(if $(MODEL),--model $(MODEL),) $(HARNESS_ARGS)
 
 ## ai-p: run a single claude -p batch invocation via LiteLLM routing
 ## Same env as ai-run — engine invoker.py inherits ANTHROPIC_BASE_URL via os.environ.
@@ -372,13 +374,14 @@ ai-p:
 		|| { echo "LiteLLM not ready on :$(LITELLM_PORT) — run: make litellm"; exit 1; }
 	ANTHROPIC_BASE_URL=http://localhost:$(LITELLM_PORT) \
 	OPENAI_BASE_URL=http://localhost:$(LITELLM_PORT) \
+	ANTHROPIC_API_KEY="$${LITELLM_MASTER_KEY}" \
 	ANTHROPIC_CUSTOM_HEADERS="x-litellm-api-key: $${LITELLM_MASTER_KEY}" \
 	$(if $(MODEL),ANTHROPIC_CUSTOM_MODEL_OPTION=$(MODEL),) \
 	CLAUDE_CODE_ENABLE_TELEMETRY=1 \
 	OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
 	OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:$(MLFLOW_PORT) \
 	OTEL_EXPORTER_OTLP_HEADERS="x-mlflow-experiment-id=2" \
-	claude -p $(AI_P_ARGS) $(if $(MODEL),--model $(MODEL),) "$(PROMPT)"
+	env -u ANTHROPIC_MAX claude -p $(AI_P_ARGS) $(if $(MODEL),--model $(MODEL),) "$(PROMPT)"
 
 # ── Public entry points ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **ai-run/ai-p**: Set `ANTHROPIC_API_KEY=$LITELLM_MASTER_KEY` so the child `claude` subprocess authenticates via API-key mode against LiteLLM. Without this, `env -u CLAUDECODE` strips the OAuth session and the child fails with "Not logged in" — `ANTHROPIC_BASE_URL=localhost:4000` means LiteLLM receives OAuth validation requests it cannot fulfill.
- **ai-run/ai-p**: Add `-u ANTHROPIC_MAX` so `claude` uses API-key mode, not Max plan OAuth (which requires Anthropic servers, not LiteLLM).
- **litellm startup**: Explicitly pass `MINIMAX_PLAN_KEY` to the sidecar env. Previously only `MINIMAX_API_KEY` was forwarded; `os.environ/MINIMAX_PLAN_KEY` in `config.yaml` relied on inherited env which is fragile when litellm starts outside an `op inject` context.

## Test plan

- [ ] `make ai-run MODEL=minimax-m3` connects and responds
- [ ] `make ai-run MODEL=minimax-m2.7` connects and responds
- [ ] `make ai-run MODEL=glm-5.1` connects and responds
- [ ] `make ai-run MODEL=deepseek-v4-pro` connects and responds
- [ ] `make ai-run MODEL=claude-sonnet-4-6` still works (Claude Max plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)