### PR TITLE
refactor(make): replace case statement with bash assoc array in %.stop

### DIFF
--- a/include.ai.mk
+++ b/include.ai.mk
@@ -104,21 +104,18 @@ port_ready = nc -z localhost $(1) 2>/dev/null
 ## [service].stop: graceful stop — SIGTERM first, SIGKILL fallback after 5s
 # Belts-and-suspenders: name-based stop also kills the associated port so
 # double-forked processes (PPID=1) that survive pkill are caught by lsof.
+# SERVICE_PORTS maps service names → ports for the port-kill fallback.
+SERVICE_PORTS := litellm:$(LITELLM_PORT) mlflow:$(MLFLOW_PORT) temporal:$(TEMPORAL_PORT) \
+                 redis:$(REDIS_PORT) postgres:$(POSTGRES_PORT) ccr:$(CCR_PORT) ktap:$(KTAP_PORT)
 %.stop:
-	@for signal in "" "-9"; do \
+	@declare -A _ports=( $(foreach p,$(SERVICE_PORTS),[$(word 1,$(subst :, ,$(p)))]=$(word 2,$(subst :, ,$(p)))) ); \
+	for signal in "" "-9"; do \
 		if echo "$*" | grep -qE '^[0-9]+$$'; then \
 			lsof -ti :$* -sTCP:LISTEN 2>/dev/null | xargs -r kill $$signal 2>/dev/null || true; \
 		else \
 			pgrep -fl "$*" | grep -vE '^[0-9]+ make|pgrep' | awk '{print $$1}' | xargs -r kill $$signal 2>/dev/null || true; \
-			case "$*" in \
-				litellm)  lsof -ti :$(LITELLM_PORT)   -sTCP:LISTEN 2>/dev/null | xargs -r kill $$signal 2>/dev/null || true ;; \
-				mlflow)   lsof -ti :$(MLFLOW_PORT)    -sTCP:LISTEN 2>/dev/null | xargs -r kill $$signal 2>/dev/null || true ;; \
-				temporal) lsof -ti :$(TEMPORAL_PORT)  -sTCP:LISTEN 2>/dev/null | xargs -r kill $$signal 2>/dev/null || true ;; \
-				redis)    lsof -ti :$(REDIS_PORT)     -sTCP:LISTEN 2>/dev/null | xargs -r kill $$signal 2>/dev/null || true ;; \
-				postgres) lsof -ti :$(POSTGRES_PORT)  -sTCP:LISTEN 2>/dev/null | xargs -r kill $$signal 2>/dev/null || true ;; \
-				ccr)      lsof -ti :$(CCR_PORT)       -sTCP:LISTEN 2>/dev/null | xargs -r kill $$signal 2>/dev/null || true ;; \
-				ktap)     lsof -ti :$(KTAP_PORT)      -sTCP:LISTEN 2>/dev/null | xargs -r kill $$signal 2>/dev/null || true ;; \
-			esac; \
+			_port="$${_ports[$*]:-}"; \
+			[ -n "$$_port" ] && lsof -ti :$$_port -sTCP:LISTEN 2>/dev/null | xargs -r kill $$signal 2>/dev/null || true; \
 		fi; \
 		sleep 3; \
 	done


### PR DESCRIPTION
## Summary

- Define `SERVICE_PORTS` as a `name:port` list — single source of truth for service→port mapping
- `%.stop` builds a bash associative array from it; port-kill uses `${_ports[$*]}`
- Adding a new service = one line in `SERVICE_PORTS`, not a new `case` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)