### PR TITLE
feat(litellm): enable LITELLM_LOG=DEBUG by default

### DIFF
--- a/include.ai.mk
+++ b/include.ai.mk
@@ -270,6 +270,7 @@ litellm: litellm-check-version
 		mkdir -p $$(dirname $(PRISMA_STAMP)) && echo "$$_schema_hash" > $(PRISMA_STAMP); \
 	fi; \
 	$(call start_server_double_fork,$(LITELLM_PORT),\
+		LITELLM_LOG=DEBUG \
 		ANTHROPIC_API_KEY="$${LITELLM_MASTER_KEY}" \
 		DATABASE_URL=postgresql://$$USER@localhost/litellm \
 		LM_STUDIO_API_TOKEN="$${LM_STUDIO_API_TOKEN}" \


### PR DESCRIPTION
## Summary

- Enables `LITELLM_LOG=DEBUG` in the litellm start env so future provider failures are diagnosable without restart.
- DEBUG captures the full outgoing HTTP request (URL + headers + body) to each upstream provider — the only level that exposes auth-header pass-through bugs like the OAuth-keychain issue PR #90 fixed.
- Cost: log volume ~10× vs INFO. Pair with logrotate (next PRs in `bin/install-ai.sh` for install + chezmoi for config).

## Security note

Request bodies (including prompt content) are written to disk under `~/ws/logs/sidecar-4000.log`. **Personal-dev only.** Do NOT enable in shared/team setups.

## Test plan

- [x] Used during PR #90 debugging to capture the exact outgoing `Authorization: Bearer` forwarded to MiniMax
- [ ] User: `make litellm.stop && make litellm` to restart with new env
- [ ] User: verify `tail ~/ws/logs/sidecar-4000.log` shows `DEBUG` entries (not just `INFO`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)