### PR TITLE
fix(ai-test): zero-model checks exit 1 when models present

### DIFF
--- a/include.ai.mk
+++ b/include.ai.mk
@@ -837,8 +837,8 @@ ai-test-infra:
 				_gemini=$$(echo "$$_body" | jq '[.data[] | select(.id | startswith("gemini"))] | length' 2>/dev/null); \
 				_codex=$$(echo "$$_body" | jq '[.data[] | select(.id | startswith("gpt-") or startswith("codex-"))] | length' 2>/dev/null); \
 				echo "  ✓ cliproxyapi auth OK ($${_gemini:-?} gemini, $${_codex:-?} codex/gpt-5 models)"; \
-				[ "$${_gemini:-0}" -eq 0 ] && echo "    ⚠ no gemini models — run: make ai-auth PROVIDER=gemini"; \
-				[ "$${_codex:-0}" -eq 0 ]  && echo "    ⚠ no codex models — run: make ai-auth PROVIDER=codex"; \
+				[ "$${_gemini:-0}" -eq 0 ] && echo "    ⚠ no gemini models — run: make ai-auth PROVIDER=gemini" || true; \
+				[ "$${_codex:-0}" -eq 0 ]  && echo "    ⚠ no codex models — run: make ai-auth PROVIDER=codex" || true; \
 				;; \
 			401|403) echo "  ✗ cliproxyapi auth EXPIRED — run: make ai-auth";; \
 			*) echo "  ⚠ cliproxyapi probe HTTP $$_code"; \


### PR DESCRIPTION
## Summary

- `ai-test-infra` aborted with `Error 1` before reaching the quick-health and MLflow sections
- Root cause: `[ N -eq 0 ] && echo "⚠ no models"` exits 1 when N>0 (the healthy case — you have models), making make interpret a successful check as failure
- Fix: add `|| true` to both the gemini and codex zero-model warning lines so the pattern always exits 0

## Test plan

- [ ] `make ai-test` runs to completion without `Error 1` when cliproxyapi returns models
- [ ] Still prints `⚠ no gemini models` warning when `_gemini=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)