### PR TITLE
chore(api-keys): disable TAVILY + SUPERSET keys; fix Taviliy typo

### DIFF
--- a/api-keys.yaml
+++ b/api-keys.yaml
@@ -173,8 +173,9 @@ SERPAPI_API_KEY:
   op_vault: DevOps
 
 TAVILY_API_KEY:
-  op_item: "Taviliy API Key Dev"
+  op_item: "Tavily API Key Dev"
   op_vault: DevOps
+  disabled: true  # not in use
 
 # ── AI infrastructure ─────────────────────────────────────────────────────────
 CEREBRAS_API_KEY:
@@ -287,6 +288,7 @@ WEBUI_SECRET_KEY:
 SUPERSET_SECRET_KEY:
   op_item: "Apache Superset Secret Dev"
   op_vault: DevOps
+  disabled: true  # not in use
 
 SLASHGPT_ENV_WEBPILOT_UID:
   op_item: "Webpilot UID Dev"


### PR DESCRIPTION
- Disable `TAVILY_API_KEY` and `SUPERSET_SECRET_KEY` (not in use)
- Fix typo: Taviliy → Tavily in vault item reference