### PR TITLE
fix(ai-test): quality gate passes thinking models

### DIFF
--- a/scripts/ai-test.sh
+++ b/scripts/ai-test.sh
@@ -177,14 +177,19 @@ run_quality() {
 			"http://localhost:$LITELLM_PORT/v1/chat/completions" \
 			-H "Content-Type: application/json" \
 			-H "Authorization: Bearer $_key" \
-			-d "{\"model\":\"$model\",\"messages\":[{\"role\":\"user\",\"content\":\"What is 2+2? Reply with just the digit.\"}],\"max_tokens\":10}" \
+			-d "{\"model\":\"$model\",\"messages\":[{\"role\":\"user\",\"content\":\"What is 2+2? Reply with just the digit.\"}],\"max_tokens\":512}" \
 			2>/dev/null |
-			python3 -c 'import sys,json; d=json.load(sys.stdin); m=d["choices"][0]["message"]; print((m.get("content") or m.get("reasoning_content","")).strip()[:20])' 2>/dev/null)
+			python3 -c 'import sys,json; d=json.load(sys.stdin); m=d["choices"][0]["message"]; print((m.get("content") or m.get("reasoning_content","")).strip())' 2>/dev/null)
+		# Grep the FULL reply for the expected digit — thinking models emit the
+		# answer after reasoning, so never truncate before the check. Display a
+		# one-line preview only. max_tokens=512 gives reasoning models room to
+		# reach the digit (max_tokens=10 cut them off mid-thought).
+		preview=$(printf '%s' "$reply" | tr '\n' ' ' | cut -c1-60)
 		if echo "$reply" | grep -q "4"; then
-			echo "  ✓ $model: '$reply'"
+			echo "  ✓ $model: '$preview'"
 			((pass++)) || true
 		else
-			echo "  ✗ $model: expected '4', got '$reply'"
+			echo "  ✗ $model: expected '4', got '$preview'"
 			((fail++)) || true
 		fi
 	done


### PR DESCRIPTION
## Problem

The `ai-test.sh` quality gate (`2+2=4` probe) failed reasoning/thinking models for two coupled reasons:

1. **`max_tokens=10`** — a thinking model spends those tokens on reasoning and never emits the final digit.
2. **`.strip()[:20]`** — even when the digit was present, the reply was truncated to 20 chars before `grep -q "4"`, cutting off the answer.

Net effect: models that are actually correct were marked as failures, and the gate (`exit 1` on any fail) blocked the test suite.

## Fix

- Bump `max_tokens` 10 → 512 so reasoning models have room to reach the digit.
- Grep the **full** reply (no pre-truncation); show only a 60-char one-line `preview` for readable output.

## Test

- `bash -n` + `shellcheck -S error` clean.
- All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)