### PR TITLE
fix(secrets): quote op:// value in generated export lines

### DIFF
--- a/lib-secrets.sh
+++ b/lib-secrets.sh
@@ -86,8 +86,11 @@ if eval "[[ -z \${$lib_name+x} ]]"; then
 				}
 				export "$env_var=$val"
 			else
-				# Profile injection — write op:// reference
-				local line="[[ -v ${env_var} ]] || export ${env_var}=${op_ref}"
+				# Profile injection — write op:// reference.
+				# Quote the value: op inject substitutes the resolved secret in place,
+				# and multi-line/whitespace values (e.g. base64 git-crypt keys) would
+				# otherwise word-split into bogus `export: not a valid identifier` errors.
+				local line="[[ -v ${env_var} ]] || export ${env_var}=\"${op_ref}\""
 				if [[ -n "$disabled_by" ]]; then
 					line="if [[ ! -v ${disabled_by} ]]; then ${line}; fi"
 				fi


### PR DESCRIPTION
## Summary

`op_load_api_keys` in `lib-secrets.sh` generated profile lines as:

```bash
[[ -v VAR ]] || export VAR=op://Vault/Item/field
```

with the value **unquoted**. `op inject` substitutes the resolved secret in place. For single-token API keys this is fine, but for **multi-line / whitespace values** — notably the base64-encoded git-crypt keys (`TNE_DATA_GITCRYPT_KEY`, `TNE_DATA_SENSITIVE_GITCRYPT_KEY`) — the resolved value word-splits, producing on **every shell startup**:

```
-bash: export: `XA8fB5+B9YveFC42OQsW...': not a valid identifier
-bash: export: `iOE5GJBdILb0lZrjMNJb/...==': not a valid identifier
```

and silently failing the git-crypt unlock (data stays encrypted).

## Fix

Quote the value in the generated line:

```bash
[[ -v VAR ]] || export VAR="op://Vault/Item/field"
```

This keeps the assignment intact regardless of resolved content. Matches the already-quoted hardcoded `ANTHROPIC_API_KEY` line in `install-1password.sh`.

## Test plan

- [ ] `bash -n lib-secrets.sh` passes
- [ ] Generated lines for git-crypt keys are quoted
- [ ] Fresh bash/zsh login shows no `export: not a valid identifier` errors
- [ ] `git-crypt status` in `~/ws/data` shows unlocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)