### PR TITLE
fix(secrets): 0x1F-delimit rows + bats tests (lib-secrets/lib-config)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,15 @@ ORG ?= tne
 
 ## Local Make commands
 ## ---
-## test: test the library
+## test: run bats unit tests (per r-cto-dev91: static + behavioral coverage)
 .PHONY: test
 test:
-	@echo "insert test code here..."
+	bats tests/ --filter-tags unit
+
+## test-all: run every bats test (unit + any system-tagged)
+.PHONY: test-all
+test-all:
+	bats tests/
 
 ## clean: remove the build directory
 .PHONY: clean

--- a/lib-secrets.sh
+++ b/lib-secrets.sh
@@ -13,7 +13,7 @@ if eval "[[ -z \${$lib_name+x} ]]"; then
 	_SECRETS_YAML="${SECRETS_YAML:-$(dirname "${BASH_SOURCE[0]}")/api-keys.yaml}"
 
 	# ── YAML parser ───────────────────────────────────────────────────────────────
-	# Parses api-keys.yaml; prints TSV rows to stdout.
+	# Parses api-keys.yaml; prints 0x1F-delimited rows to stdout (NOT tab — see NOTE below).
 	# Columns: env_var op_item op_field op_vault disabled_by equivalent_of
 	# Args: [yaml_file] [env_var_filter...]
 	_secrets_parse_yaml() {
@@ -38,8 +38,14 @@ if eval "[[ -z \${$lib_name+x} ]]"; then
 			   (.value.op_vault // \"DevOps\"),
 			   (.value.disabled_by // \"\"),
 			   (.value.equivalent_of // \"\")]
-			| @tsv" "$yaml_file"
+			| @tsv" "$yaml_file" | tr '\t' '\037'
 	}
+	# NOTE: fields are joined with 0x1F (unit separator), NOT tab. A tab is an
+	# IFS-whitespace char, so `IFS=$'\037' read` collapses consecutive tabs and
+	# shifts columns whenever a field is empty (e.g. equivalent_of entries have
+	# no op_item) — which silently emitted broken `op://<equivalent>/...` refs.
+	# 0x1F is non-whitespace, so empty fields are preserved. All readers below
+	# MUST use `IFS=$'\037'`.
 
 	# ── op_load_api_keys ──────────────────────────────────────────────────────────
 	# Write op:// references for each key into a shell profile, or export directly.
@@ -67,7 +73,7 @@ if eval "[[ -z \${$lib_name+x} ]]"; then
 			return 1
 		}
 
-		while IFS=$'\t' read -r env_var op_item op_field op_vault disabled_by equivalent; do
+		while IFS=$'\037' read -r env_var op_item op_field op_vault disabled_by equivalent; do
 			[[ -z "$env_var" ]] && continue
 			# equivalents go in op_write_equivalents, not here
 			[[ -n "$equivalent" ]] && continue
@@ -112,7 +118,7 @@ if eval "[[ -z \${$lib_name+x} ]]"; then
 		local _out
 		_out=$(_secrets_parse_yaml "$_SECRETS_YAML") || return 1
 
-		while IFS=$'\t' read -r env_var _item _field _vault _disabled_by equivalent; do
+		while IFS=$'\037' read -r env_var _item _field _vault _disabled_by equivalent; do
 			[[ -z "$equivalent" ]] && continue
 			local line="${env_var}=\"\$${equivalent}\""
 			if [[ -n "$profile_file" ]]; then
@@ -134,7 +140,7 @@ if eval "[[ -z \${$lib_name+x} ]]"; then
 		if [[ ${#vars[@]} -eq 0 ]]; then
 			local _out
 			_out=$(_secrets_parse_yaml "$_SECRETS_YAML") || return 1
-			while IFS=$'\t' read -r env_var _rest; do
+			while IFS=$'\037' read -r env_var _rest; do
 				[[ -z "$env_var" ]] && continue
 				vars+=("$env_var")
 			done <<<"$_out"

--- a/tests/fixtures/api-keys-test.yaml
+++ b/tests/fixtures/api-keys-test.yaml
@@ -1,0 +1,30 @@
+# Test fixture for lib-secrets.bats — not real secrets, just op:// reference shapes.
+SIMPLE_API_KEY:
+  op_item: Simple API Key Dev
+  op_field: api key
+  op_vault: DevOps
+
+# Value resolves to a multi-line base64 blob — the case that broke when unquoted
+# (export VAR=<frag1> <frag2> → "not a valid identifier"). See tne-ai/lib#127.
+TNE_DATA_SENSITIVE_GITCRYPT_KEY:
+  op_item: TNE Data Git Crypt Private Key
+  op_field: key
+  op_vault: Finance
+
+# Gated by an OAuth flag — must be wrapped in `if [[ ! -v FLAG ]]; then ... fi`.
+OPENAI_API_KEY:
+  op_item: OpenAI API Key Dev
+  op_field: api key
+  op_vault: DevOps
+  disabled_by: CODEX_CHATGPT
+
+# equivalent_of entries are emitted by op_write_equivalents, NOT op_load_api_keys.
+GOOGLE_API_KEY:
+  equivalent_of: GEMINI_API_KEY
+
+# disabled entries must be skipped entirely.
+DEAD_KEY:
+  op_item: Dead Key
+  op_field: api key
+  op_vault: DevOps
+  disabled: true

--- a/tests/lib-config.bats
+++ b/tests/lib-config.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# lib-config.bats — unit tests for config_profile_* path resolvers in lib-config.sh
+# Per r-cto-dev91: static (shellcheck) + behavioral (bats) coverage required.
+# Per r-cto-dev148 / r-cto-dev155: these functions encode the shell-file routing
+# contract (POSIX .profile vs exportable .bash_profile/.zprofile vs interactive .zshrc).
+#
+# Run unit only (CI-safe):  bats tests/lib-config.bats --filter-tags unit
+# Run via make:             make test-lib-config
+
+setup() {
+	LIB_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+	HOME=/tmp/bats-home-fixture
+	# shellcheck source=/dev/null
+	source "$LIB_DIR/lib-config.sh"
+}
+
+# ── exportable vs non-exportable targets (the r-cto-dev148 contract) ──────────
+
+# bats test_tags=unit
+@test "config_profile_bash returns POSIX ~/.profile (no op inject allowed)" {
+	run config_profile_bash
+	[ "$status" -eq 0 ]
+	[ "$output" = "$HOME/.profile" ]
+}
+
+# bats test_tags=unit
+@test "config_profile_exportable_bash returns ~/.bash_profile (bash op inject target)" {
+	run config_profile_exportable_bash
+	[ "$status" -eq 0 ]
+	[ "$output" = "$HOME/.bash_profile" ]
+}
+
+# bats test_tags=unit
+@test "config_profile_zsh returns ~/.zprofile" {
+	run config_profile_zsh
+	[ "$status" -eq 0 ]
+	[ "$output" = "$HOME/.zprofile" ]
+}
+
+# bats test_tags=unit
+@test "config_profile_exportable_zsh aliases ~/.zprofile (same file as config_profile_zsh)" {
+	run config_profile_exportable_zsh
+	[ "$status" -eq 0 ]
+	[ "$output" = "$HOME/.zprofile" ]
+	[ "$(config_profile_exportable_zsh)" = "$(config_profile_zsh)" ]
+}
+
+# bats test_tags=unit
+@test "config_profile_nonexportable_zsh returns interactive ~/.zshrc" {
+	run config_profile_nonexportable_zsh
+	[ "$status" -eq 0 ]
+	[ "$output" = "$HOME/.zshrc" ]
+}
+
+# bats test_tags=unit
+@test "config_profile_nonexportable_bash returns interactive ~/.bashrc" {
+	run config_profile_nonexportable_bash
+	[ "$status" -eq 0 ]
+	[ "$output" = "$HOME/.bashrc" ]
+}
+
+# ── invariant: POSIX .profile is never the op-inject (exportable) target ──────
+
+# bats test_tags=unit
+@test "exportable targets are never ~/.profile (POSIX sh cannot run op inject)" {
+	[ "$(config_profile_exportable_bash)" != "$HOME/.profile" ]
+	[ "$(config_profile_exportable_zsh)" != "$HOME/.profile" ]
+}
+
+# bats test_tags=unit
+@test "config_profile dispatches by shell (zsh vs bash)" {
+	ZSH_VERSION=5.9 run config_profile
+	[ "$output" = "$HOME/.zprofile" ]
+}

--- a/tests/lib-secrets.bats
+++ b/tests/lib-secrets.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+# lib-secrets.bats — unit tests for op_load_api_keys / op_write_equivalents.
+# Per r-cto-dev91: static (shellcheck) + behavioral (bats) coverage required.
+#
+# Regression anchor: tne-ai/lib#127 — generated `export VAR=op://...` lines MUST
+# quote the value, or a multi-line resolved secret (base64 git-crypt key) word-
+# splits into `export: not a valid identifier` on every shell startup.
+#
+# These tests use SECRETS_YAML=fixture and SECRETS_EXPORT_DIRECT=false so no op
+# CLI / 1Password / network is required — they assert the GENERATED text only.
+#
+# Run unit only (CI-safe):  bats tests/lib-secrets.bats --filter-tags unit
+# Run via make:             make test-lib-secrets
+
+setup() {
+	command -v yq >/dev/null || skip "yq v4 not installed"
+	LIB_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+	export SECRETS_YAML="$LIB_DIR/tests/fixtures/api-keys-test.yaml"
+	export SECRETS_EXPORT_DIRECT=false
+	# shellcheck source=/dev/null
+	source "$LIB_DIR/lib-secrets.sh"
+}
+
+# ── op_load_api_keys: the quoting contract (regression for #127) ──────────────
+
+# bats test_tags=unit
+@test "op_load_api_keys quotes every op:// value" {
+	run op_load_api_keys
+	[ "$status" -eq 0 ]
+	# No line may assign an UNquoted op:// value (i.e. `=op://`); all must be `="op://`.
+	if grep -qE '=op://' <<<"$output"; then
+		echo "UNQUOTED op:// value found:" >&2
+		grep -nE '=op://' <<<"$output" >&2
+		return 1
+	fi
+}
+
+# bats test_tags=unit
+@test "op_load_api_keys emits quoted git-crypt key (the #127 break case)" {
+	run op_load_api_keys
+	[ "$status" -eq 0 ]
+	[[ "$output" == *'export TNE_DATA_SENSITIVE_GITCRYPT_KEY="op://Finance/TNE Data Git Crypt Private Key/key"'* ]]
+}
+
+# bats test_tags=unit
+@test "op_load_api_keys guards each line with [[ -v VAR ]] ||" {
+	run op_load_api_keys
+	[[ "$output" == *'[[ -v SIMPLE_API_KEY ]] || export SIMPLE_API_KEY='* ]]
+}
+
+# bats test_tags=unit
+@test "op_load_api_keys wraps disabled_by keys in a flag guard" {
+	run op_load_api_keys
+	[[ "$output" == *'if [[ ! -v CODEX_CHATGPT ]]; then'*'OPENAI_API_KEY'*'fi'* ]]
+}
+
+# bats test_tags=unit
+@test "op_load_api_keys skips equivalent_of entries" {
+	run op_load_api_keys
+	[[ "$output" != *'GOOGLE_API_KEY=op'* ]]
+	[[ "$output" != *'export GOOGLE_API_KEY'* ]]
+}
+
+# bats test_tags=unit
+@test "op_load_api_keys skips disabled:true entries" {
+	run op_load_api_keys
+	[[ "$output" != *'DEAD_KEY'* ]]
+}
+
+# bats test_tags=unit
+@test "op_load_api_keys filters to requested env vars" {
+	run op_load_api_keys "" SIMPLE_API_KEY
+	[[ "$output" == *'SIMPLE_API_KEY'* ]]
+	[[ "$output" != *'OPENAI_API_KEY'* ]]
+}
+
+# ── op_write_equivalents ──────────────────────────────────────────────────────
+
+# bats test_tags=unit
+@test "op_write_equivalents emits VAR=\"\$OTHER\" alias lines" {
+	run op_write_equivalents
+	[ "$status" -eq 0 ]
+	# shellcheck disable=SC2016  # literal match — $GEMINI_API_KEY must NOT expand
+	[[ "$output" == *'GOOGLE_API_KEY="$GEMINI_API_KEY"'* ]]
+}
+
+# bats test_tags=unit
+@test "op_write_equivalents does NOT emit op:// keys" {
+	run op_write_equivalents
+	[[ "$output" != *'op://'* ]]
+}
+
+# ── regression: empty-field column shift (tab-collapse) ───────────────────────
+# An equivalent_of entry has an empty op_item. When the parser used tab-delimited
+# rows and readers used IFS=$'\t' (tab = IFS-whitespace), consecutive tabs
+# collapsed and every column shifted left, so `equivalent` read empty and the
+# alias was emitted as a broken `op://<equivalent>/api key/DevOps` ref instead of
+# being routed to op_write_equivalents. Parser now uses 0x1F (non-whitespace).
+
+# bats test_tags=unit
+@test "regression: equivalent_of alias never becomes an op:// ref" {
+	run op_load_api_keys
+	# GOOGLE_API_KEY is equivalent_of GEMINI_API_KEY — must NOT appear as op://…
+	[[ "$output" != *'op://GEMINI_API_KEY/'* ]]
+	[[ "$output" != *'GOOGLE_API_KEY="op://'* ]]
+}
+
+# bats test_tags=unit
+@test "regression: empty op_item does not shift columns (git-crypt vault stays Finance)" {
+	run op_load_api_keys
+	# If columns shifted, the vault segment would be wrong. Assert the exact ref.
+	[[ "$output" == *'export TNE_DATA_SENSITIVE_GITCRYPT_KEY="op://Finance/TNE Data Git Crypt Private Key/key"'* ]]
+}


### PR DESCRIPTION
## Summary

Phase 1 of wiring tests for `./lib` (was 0 bats files) — and it immediately caught a **real production bug**.

### Bug: tab-collapse column shift
`_secrets_parse_yaml` emitted **tab-delimited** rows; the three readers used `IFS=$'\t'`. A tab is an **IFS-whitespace** character, so bash collapses consecutive tabs. Any row with an empty field — and **every `equivalent_of` entry has an empty `op_item`** — shifts all columns left. Consequences:

- `op_load_api_keys` emitted aliases as **broken op:// refs**, e.g. `export ZHIPU_API_KEY="op://Z_AI_PLAN_KEY/api key/DevOps"` — which actually shipped into real `~/.zprofile` / `~/.bash_profile`.
- `op_write_equivalents` silently dropped some aliases (emitted GOOGLE, not ZHIPU).

### Fix
Parser now joins fields with **0x1F** (unit separator, non-whitespace) via `tr '\t' '\037'`; all three readers use `IFS=$'\037'`. Empty fields are preserved, columns stay aligned.

Verified against the real `api-keys.yaml`: broken refs gone, `op_write_equivalents` now emits both GOOGLE and ZHIPU aliases.

### Tests (per r-cto-dev91 static + behavioral mandate)
- `tests/lib-config.bats` — `config_profile_*` shell-file routing contract (8)
- `tests/lib-secrets.bats` — op:// quoting (#127 regression), `equivalent_of` skip, `disabled_by` guard, filter, and **empty-field column-shift regression** (11)
- `make test` → `bats tests/ --filter-tags unit`; 19/19 green, shellcheck clean

## Follow-up
- A forthcoming r-rule will codify the data-format preference **yaml > json > csv > tsv** and ban tab-delimited + `IFS=$'\t'` shell parsing (the trap this bug fell into).

## Test plan
- [ ] `make test` → 19 pass
- [ ] `op_load_api_keys` on real yaml emits no `op://<VAR>/` alias refs
- [ ] `op_write_equivalents` emits GOOGLE + ZHIPU aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)