### PR TITLE
ci(workflow): run bats unit suite on release tags (guarded)

### DIFF
--- a/.github/workflows/lint.workflow.yaml
+++ b/.github/workflows/lint.workflow.yaml
@@ -10,6 +10,9 @@ on:
       - main
       - master
       - rich-*
+    # Release tags run the bats unit suite so a version bump is validated (r-cto-dev91).
+    tags:
+      - "v*"
   pull_request:
   workflow_dispatch:
 
@@ -174,3 +177,23 @@ jobs:
         # #yamllint $(find . -name "*.yaml" -o -name "*.yml")
         # #echo running yamllint
         # #yamllint .
+
+  # Behavioral shell tests (per r-cto-dev91: static shellcheck in pre-commit,
+  # behavioral bats here). Guarded — skips silently if no tests/*.bats, so it is
+  # safe fleet-wide. Runs on PRs/pushes AND release tags (see `tags: v*` above).
+  bats:
+    runs-on: ${{ github.event.repository.visibility == 'public' && 'ubuntu-latest' || vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout action
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run bats unit tests (guarded — skip if none)
+        run: |
+          if ls tests/*.bats >/dev/null 2>&1; then
+            make test
+          else
+            echo "no tests/*.bats in this repo — skipping bats job"
+          fi

--- a/workflow.base/lint.workflow.yaml
+++ b/workflow.base/lint.workflow.yaml
@@ -9,6 +9,10 @@ on:
       - main
       - master
       - rich-*
+    # Release tags run the full workflow (incl. the bats unit suite) regardless
+    # of paths — a version bump must be validated end to end (r-cto-dev91).
+    tags:
+      - "v*"
     paths:
       - "**/*.py"
       - "python/**"
@@ -99,3 +103,24 @@ jobs:
         uses: pre-commit/action@v3.0.1
         with:
           extra_args: --files ${{ steps.changed.outputs.all_changed_files }}
+
+  # Behavioral shell tests (per r-cto-dev91: static shellcheck runs in pre-commit,
+  # behavioral bats here). Guarded — skips silently in repos with no tests/*.bats,
+  # so this shared workflow is safe fleet-wide. Runs on PRs/pushes AND release
+  # tags (see the `tags: v*` trigger above) so a version bump is validated.
+  bats:
+    runs-on: ${{ github.event.repository.visibility == 'public' && 'ubuntu-latest' || vars.RUNNER_LABEL || 'ubuntu-latest' }}
+    steps:
+      - name: Checkout action
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run bats unit tests (guarded — skip if none)
+        run: |
+          if ls tests/*.bats >/dev/null 2>&1; then
+            make test
+          else
+            echo "no tests/*.bats in this repo — skipping bats job"
+          fi


### PR DESCRIPTION
## Summary

Adds a **`tags: v*` push trigger** and a **guarded bats job** to the shared workflow — so a version bump runs the unit test suite.

Per r-cto-dev110 (two-location rule), edited both:
- `workflow.base/lint.workflow.yaml` — the canonical fleet-wide source
- `.github/workflows/lint.workflow.yaml` — lib's live copy (immediate effect)

The bats job runs `make test` **only if `tests/*.bats` exists**, so it is safe for repos that have no bats suite (skips silently). Static shellcheck already runs in pre-commit; this adds the behavioral layer per r-cto-dev91.

## Note on drift
lib's live workflow and `workflow.base/` have drifted (different formats). This PR does **not** attempt a full re-sync (risky, out of scope) — it applies the same two minimal pieces to both. Re-syncing all repos to `workflow.base/` via `make install-repo` is a separate cleanup.

## Test plan
- [ ] YAML valid (both files)
- [ ] Push a `v*` tag → bats job runs `make test`
- [ ] Repo without `tests/*.bats` → bats job skips cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)