### PR TITLE
fix(pre-commit): check-docs-sync genuine no-op when script absent

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -254,14 +254,16 @@ repos:
         exclude: Dockerfile.dockerignore
 
   # Claude plugin docs sync check
-  # Verifies README.md and AGENTS.md stay in sync with skills/ directory
-  # No-op for repos without scripts/cai22-check-docs-sync.sh
+  # Verifies README.md and AGENTS.md stay in sync with skills/ directory.
+  # Genuine no-op for repos without scripts/cai22-check-docs-sync.sh (e.g. lib,
+  # which is not a plugin repo). `language: script` ERRORS when the entry file is
+  # missing, so we use `language: system` + a guard that exits 0 when absent.
   - repo: local
     hooks:
       - id: check-docs-sync
         name: Check plugin docs sync with skills
-        entry: scripts/cai22-check-docs-sync.sh
-        language: script
+        entry: bash -c 'if [ -x scripts/cai22-check-docs-sync.sh ]; then exec scripts/cai22-check-docs-sync.sh; fi'
+        language: system
         files: '(skills/|README\.md|AGENTS\.md)'
         pass_filenames: false
 


### PR DESCRIPTION
## Summary

lib's `.pre-commit-config.yaml` carries a plugin-repo hook `check-docs-sync` whose entry `scripts/cai22-check-docs-sync.sh` **does not exist in lib** (lib is not a plugin repo). With `language: script`, pre-commit **errors** (`Executable not found`) whenever a `README.md`/`AGENTS.md`/`skills/` file changes.

### Why it wasn't caught earlier
The hook's `files:` filter is `(skills/|README\.md|AGENTS\.md)`. Recent lib PRs (#128, #130) only touched `.sh`/`.bats`/`Makefile`/workflow YAML — none matched, so the hook never ran. #131 edited `workflow.base/README.md` → matched → hook fired → script missing → **CI pre-commit failed** (had to admin-merge). The breakage was latent, only surfacing on a README/skills change.

### Fix
Switch to `language: system` with a guard that `exec`s the script only if present, else exits 0 — implementing the "no-op for repos without the script" intent the comment already claimed.

Verified: editing README.md now yields `check-docs-sync ... Passed` (no-op) instead of "Executable not found".

## Test plan
- [ ] `pre-commit run check-docs-sync --files README.md` → Passed in lib (no script)
- [ ] In a plugin repo (script present), the hook still runs the real check

🤖 Generated with [Claude Code](https://claude.com/claude-code)