### PR TITLE
feat(precommit): bump pre-commit hook versions

### DIFF
--- a/pre-commit-config.full.yaml
+++ b/pre-commit-config.full.yaml
@@ -93,7 +93,7 @@ repos:
 
   # this is bettert han the jumanji version as it uses go to build
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.12.0-2
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
         exclude: (.*\.zsh$|\.zprofile|\.zshrc)
@@ -107,7 +107,7 @@ repos:
 
   # replace markdownlint-cli with markdownlint-cli2 which is supposed to be faster
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.21.0
+    rev: v0.23.0
     hooks:
       - id: markdownlint-cli2
         args: [--fix]
@@ -116,7 +116,7 @@ repos:
   # prettier for markdown formatting (like shfmt for shell)
   # rbubley fork tracks stable releases (pre-commit/mirrors-prettier is archived)
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.8.1
+    rev: v3.8.5
     hooks:
       - id: prettier
         types_or: [markdown]
@@ -131,7 +131,7 @@ repos:
   # https://github.com/gitleaks/gitleaks - secret scanning (150+ patterns)
   # replaces detect-aws-credentials and detect-private-key with broader coverage
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
+    rev: v8.30.1
     hooks:
       - id: gitleaks
 
@@ -200,7 +200,7 @@ repos:
   # black, flake8, and pydocstyle
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.15.2
+    rev: v0.15.20
     hooks:
       # Run the linter.
       - id: ruff
@@ -217,7 +217,7 @@ repos:
       - id: jupytext
         args: [--sync, --pipe, ruff]
         additional_dependencies:
-          - ruff==0.15.2
+          - ruff==0.15.20
           #- black==23.3.0
 
   # strips everything out so use pre-commit-jupyter instead


### PR DESCRIPTION
## Summary

- pre-commit-shfmt: v3.12.0-2 → v3.13.1-1
- markdownlint-cli2: v0.21.0 → v0.23.0
- mirrors-prettier: v3.8.1 → v3.8.5
- ruff-pre-commit: v0.15.2 → v0.15.20
- jupytext additional_dependencies ruff: 0.15.2 → 0.15.20 (must match ruff hook rev)
- gitleaks: v8.30.0 → v8.30.1

Synced with tne-plugins `.pre-commit-config.yaml` bump in PR tne-ai/tne-plugins#3483.

## Test plan

- [ ] Pre-commit hooks run cleanly after this change
- [ ] ruff version in jupytext deps matches ruff hook rev

🤖 Generated with [Claude Code](https://claude.com/claude-code)