### PR TITLE
fix(ai): Moonshot Dev key + .ai endpoint; catch model-probe failures

### DIFF
--- a/api-keys.yaml
+++ b/api-keys.yaml
@@ -69,13 +69,14 @@ Z_AI_PLAN_KEY:
   ccr_provider: z.ai
 
 MOONSHOT_API_KEY:
-  op_item: "Moonshot API Key Prod"
-  op_item_id: "fs4np24dsdyz5smfrxxwxrodri"
+  op_item: "Moonshot API Key Dev"
   op_vault: DevOps
-  # enabled 2026-06-22 — Kimi K2 moved from Alibaba Coding Plan to Moonshot PAYG
-  models_url: https://api.moonshot.cn/v1/models
+  # enabled 2026-06-22 — Kimi K2 moved from Alibaba Coding Plan to Moonshot PAYG.
+  # The Dev key is an international key: api.moonshot.ai returns 200, .cn returns
+  # 401. Use .ai everywhere (r-cto-dev162 motivation).
+  models_url: https://api.moonshot.ai/v1/models
   models_pattern: "^kimi-k2"
-  litellm_base: https://api.moonshot.cn/v1
+  litellm_base: https://api.moonshot.ai/v1
   litellm_model_prefix: "openai/"
   ccr_provider: kimi
 

--- a/lib-ai.sh
+++ b/lib-ai.sh
@@ -145,15 +145,20 @@ print(int(age / 86400))
 			models_pattern _litellm_base _litellm_key _litellm_prefix ccr_provider; do
 			[[ -z "$env_var" || -z "${!env_var:-}" ]] && continue
 
-			local json
+			# Catch the probe failure and report it — a 401/timeout on one
+			# provider must not abort the whole run under set -e (r-cto-dev162).
+			local json=""
 			if [[ "$models_auth" == "query" ]]; then
 				json=$(curl -sf --connect-timeout 5 \
-					"${models_url}?${models_auth_param}=${!env_var}" 2>/dev/null)
+					"${models_url}?${models_auth_param}=${!env_var}" 2>/dev/null) || json=""
 			else
 				json=$(curl -sf --connect-timeout 5 \
-					-H "Authorization: Bearer ${!env_var}" "$models_url" 2>/dev/null)
+					-H "Authorization: Bearer ${!env_var}" "$models_url" 2>/dev/null) || json=""
 			fi
-			[[ -z "$json" ]] && continue
+			if [[ -z "$json" ]]; then
+				echo "  ⚠ ${env_var}: model probe failed at ${models_url} (key/endpoint?) — skipping, using fallback list" >&2
+				continue
+			fi
 
 			local ids
 			ids=$(echo "$json" | python3 -c "


### PR DESCRIPTION
Two fixes applying this session's new rules:
- **api-keys.yaml** Moonshot block: Prod item + Prod UUID + `.cn` → `Moonshot API Key Dev` by name (no UUID) + `api.moonshot.ai` (Dev key is international: .ai=200, .cn=401).
- **lib-ai.sh** `ai_resolve_model_names`: catch the models_url curl so a 401/timeout on one provider is reported and skipped, not aborted under `set -e` (r-cto-dev162). This was the bare **exit 22** that killed the whole litellm config regen.

Part of #91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)