### PR TITLE
fix(lint): disable MD049 — prettier/markdownlint emphasis cycle

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -21,5 +21,9 @@ config:
   # MD034: Bare URLs — allow email addresses
   MD034: false
 
+  # MD049: Emphasis style — prettier uses underscores, markdownlint would enforce asterisks.
+  # Disabling lets prettier control emphasis style and prevents an infinite formatter cycle.
+  MD049: false
+
   # MD060: Table column style — prettier controls formatting
   MD060: false

--- a/markdownlint-cli2.base.yaml
+++ b/markdownlint-cli2.base.yaml
@@ -58,6 +58,10 @@ config:
   # MD052: Reference links/images — generated content may have unresolved refs
   MD052: false
 
+  # MD049: Emphasis style — prettier uses underscores, markdownlint would enforce asterisks.
+  # Disabling lets prettier control emphasis style and prevents an infinite formatter cycle.
+  MD049: false
+
   # MD055: Table pipe style — prettier controls formatting
   MD055: false
 


### PR DESCRIPTION
## Summary

- prettier v3.8.5 (pinned in pre-commit) normalizes emphasis to `_underscores_`
- markdownlint MD049 enforces `*asterisks*`
- Both tools run in CI pre-commit — they cycle indefinitely, each reverting the other

Fix: disable MD049 in both template files so prettier controls emphasis style, consistent with how `MD055`/`MD060` (table style) are already deferred to prettier.

Propagates the fix from tne-plugins PR #3582 to the lib templates that get copied to repos via `make install-repo`.

## Files changed

- `markdownlint-cli2.base.yaml` — base template for repos (copied by `make install-repo`)
- `.markdownlint-cli2.yaml` — home config installed by `install-markdown.sh`

## Test plan

- [ ] After merging + `make install-repo`, `pre-commit run --all-files` completes without a "files were modified" loop on `.md` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)