### PR TITLE
fix(keys): restore ALIBABA_PLAN_KEY for Qwen token plan

### DIFF
--- a/api-keys.yaml
+++ b/api-keys.yaml
@@ -90,13 +90,15 @@ ALIBABA_API_KEY:
   op_vault: DevOps
 
 ALIBABA_PLAN_KEY:
-  op_item: "Alibaba Cloud Api Key Dev"
+  op_item: "Alibaba Cloud Plan API Key Dev"
   op_field: "api key"
   op_vault: DevOps
-  disabled: true  # deprecated 2026-06-22 — Kimi K2 moved to Moonshot PAYG
-  models_url: https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models
-  models_pattern: "^(qwen|wanx)"
-  litellm_base: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+  # Alibaba MaaS Team Edition Token Plan — covers Qwen models only.
+  # Kimi moved to Moonshot PAYG 2026-06-22 but Qwen remains on this plan.
+  # Key and endpoint are tightly coupled — do NOT use with dashscope-intl (401).
+  models_url: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1/models
+  models_pattern: "^qwen"
+  litellm_base: https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1
   litellm_model_prefix: "openai/"
 
 DEEPSEEK_API_KEY:


### PR DESCRIPTION
## Summary
- Re-enables `ALIBABA_PLAN_KEY` in `api-keys.yaml` — was incorrectly deprecated
- Fixes `op_item` name: `"Alibaba Cloud Api Key Dev"` → `"Alibaba Cloud Plan API Key Dev"`
- Corrects endpoint from `dashscope-intl` to `token-plan.ap-southeast-1.maas.aliyuncs.com`
- Adds comment explaining Qwen stays on Token Plan even though Kimi moved to Moonshot

## Why
The 2026-06-22 deprecation comment was wrong. Kimi K2 moved to Moonshot PAYG,
but the Alibaba MaaS Team Edition Token Plan is still active for qwen-max/qwen-turbo.
Key and endpoint are tightly coupled — wrong pair → 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)