### PR TITLE
fix(moonshot): correct models_url to api.moonshot.ai domain

### DIFF
--- a/api-keys.yaml
+++ b/api-keys.yaml
@@ -73,9 +73,9 @@ MOONSHOT_API_KEY:
   op_item_id: "fs4np24dsdyz5smfrxxwxrodri"
   op_vault: DevOps
   # enabled 2026-06-22 — Kimi K2 moved from Alibaba Coding Plan to Moonshot PAYG
-  models_url: https://api.moonshot.cn/v1/models
+  models_url: https://api.moonshot.ai/v1/models
   models_pattern: "^kimi-k2"
-  litellm_base: https://api.moonshot.cn/v1
+  litellm_base: https://api.moonshot.ai/v1
   litellm_model_prefix: "openai/"
   ccr_provider: kimi
 


### PR DESCRIPTION
## Summary
- `models_url` and `litellm_base` for `MOONSHOT_API_KEY` pointed to `api.moonshot.cn` — returns 401 for international keys
- Fixed to `api.moonshot.ai` (global endpoint)
- Resolves false `EXPIRED or INVALID (401)` in `check-ai-keys.sh` for Moonshot/Kimi K2

## Test plan
- [ ] `bash check-ai-keys.sh` → `MOONSHOT_API_KEY: valid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)