### PR TITLE
feat(make): wire sync-plugin-lib/bin/plugin targets into include.tne.mk

### DIFF
--- a/include.tne.mk
+++ b/include.tne.mk
@@ -3,6 +3,23 @@
 ## -----
 ORG ?= tne
 
+PLUGIN_REPO ?= $(WS_DIR)/git/src/sys/tne-plugins
+PLUGIN_SCRIPTS ?= $(PLUGIN_REPO)/plugins/tne/scripts
+
+## sync-plugin-lib: distill src/lib/ into plugins/tne/lib/
+.PHONY: sync-plugin-lib
+sync-plugin-lib:
+	$(PLUGIN_SCRIPTS)/sync-lib.sh $(PLUGIN_REPO)
+
+## sync-plugin-bin: distill src/bin/ launchers into plugins/tne/bin/
+.PHONY: sync-plugin-bin
+sync-plugin-bin:
+	$(PLUGIN_SCRIPTS)/sync-bin.sh $(PLUGIN_REPO)
+
+## sync-plugin: run both lib and bin sync
+.PHONY: sync-plugin
+sync-plugin: sync-plugin-lib sync-plugin-bin
+
 STUDIO_SUBMODULE_DIR ?= $(WS_DIR)/git/src/user
 STUDIO_AWS_S3 ?= s3://bp-authoring-files/d
 STUDIO_PREFIX ?= studio


### PR DESCRIPTION
## Summary
- `sync-lib.sh`/`sync-bin.sh` already worked standalone but had no `make` entry point
- Adds thin `.PHONY` wrapper targets: `sync-plugin-lib`, `sync-plugin-bin`, `sync-plugin`
- Logic stays in the scripts; Makefile targets just make them discoverable/typeable and `make help`-documented

## Test plan
- [x] `make sync-plugin-lib` in a repo with the standard template Makefile
- [x] `make sync-plugin-bin`
- [x] `make sync-plugin` runs both