### PR TITLE
feat(lib): add port_open helper to lib-network.sh

### DIFF
--- a/lib-network.sh
+++ b/lib-network.sh
@@ -188,3 +188,12 @@ read_ips() {
 		fi
 	done <"$file"
 }
+
+# Check whether a TCP port is accepting connections on a host.
+# usage: port_open [host] port   (host defaults to localhost)
+port_open() {
+	local host="${2:+$1}"
+	local port="${2:-$1}"
+	host="${host:-localhost}"
+	nc -z "$host" "$port" 2>/dev/null
+}


### PR DESCRIPTION
## Summary
- Adds a `port_open [host] port` TCP-liveness helper (`nc -z` wrapper) to `lib-network.sh`.

## Why
tne-plugins' `compass.sh` needs this and previously hand-rolled it inline. Per r-cio-install91-plugin-sync (src/lib is the source of truth for shared functions), promoting it here lets sync-lib.sh distill it into the plugin instead of duplicating the one-liner per-repo.

## Test plan
- [x] `bash -n lib-network.sh`